### PR TITLE
fix: PreimageOracle off-by-one

### DIFF
--- a/rvsol/src/PreimageOracle.sol
+++ b/rvsol/src/PreimageOracle.sol
@@ -74,8 +74,8 @@ contract PreimageOracle is IPreimageOracle {
             // len(sig) + len(partOffset) + len(preimage offset) = 4 + 32 + 32 = 0x44
             size := calldataload(0x44)
 
-            // revert if part offset > size+8 (i.e. parts must be within bounds)
-            if gt(_partOffset, add(size, 8)) {
+            // revert if part offset >= size+8 (i.e. parts must be within bounds)
+            if iszero(lt(_partOffset, add(size, 8))) {
                 // Store "PartOffsetOOB()"
                 mstore(0, 0xfe254987)
                 // Revert with "PartOffsetOOB()"

--- a/rvsol/test/PreimageOracle.t.sol
+++ b/rvsol/test/PreimageOracle.t.sol
@@ -133,6 +133,16 @@ contract PreimageOracle_Test is Test {
         assertTrue(ok);
     }
 
+    /// @notice Tests that adding a global keccak256 pre-image at the part boundary reverts.
+    function test_loadKeccak256PreimagePart_partBoundary_reverts() public {
+        bytes memory preimage = hex"deadbeef";
+        uint256 offset = preimage.length + 8;
+
+        // TODO: remove magic errors
+        vm.expectRevert(0xfe254987);
+        oracle.loadKeccak256PreimagePart(offset, preimage);
+    }
+
     /// @notice Tests that a pre-image cannot be set with an out-of-bounds offset.
     function test_loadLocalData_outOfBoundsOffset_reverts() public {
         bytes32 preimage = bytes32(uint256(0xdeadbeef));


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->



**Description**

Mirrors https://github.com/ethereum-optimism/optimism/pull/9035 which corrects off by one error in preimage oracle contract.

**Tests**

Adds single test which is also mirrored.

**Additional context**

Current dependencies on/for this PR:
- master
    - **PR** https://github.com/ethereum-optimism/asterisc/pull/9 
        -  **PR** https://github.com/ethereum-optimism/asterisc/pull/10
            - **PR** https://github.com/ethereum-optimism/asterisc/pull/11 (this PR)
                - **PR** https://github.com/ethereum-optimism/asterisc/pull/12
