### PR TITLE
feat: Deduplicate localize method for `Step.sol`

### DIFF
--- a/rvsol/src/Step.sol
+++ b/rvsol/src/Step.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {IPreimageOracle} from "@optimism/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol";
+import {PreimageKeyLib} from "@optimism/packages/contracts-bedrock/src/cannon/PreimageKeyLib.sol";
 
 contract Step {
 
@@ -9,6 +10,11 @@ contract Step {
 
     constructor(IPreimageOracle _preimageOracle) {
         preimageOracle = _preimageOracle;
+    }
+
+    // Use public method because compiler optimizes out if not
+    function localize(bytes32 _key, bytes32 _localContext) public view returns (bytes32 localizedKey_) {
+        return PreimageKeyLib.localize(_key, _localContext);
     }
 
     // Executes a single RISC-V instruction, starting from
@@ -775,17 +781,22 @@ contract Step {
             }
 
             function localize(preImageKey, localContext_) -> localizedKey {
-                // TODO: deduplicate definition of localize using lib
-                // Grab the current free memory pointer to restore later.
-                let ptr := mload(0x40)
-                // Store the local data key and caller next to each other in memory for hashing.
-                mstore(0, preImageKey)
-                mstore(0x20, caller())
-                mstore(0x40, localContext_)
-                // Localize the key with the above `localize` operation.
-                localizedKey := or(and(keccak256(0, 0x60), not(shl(248, 0xFF))), shl(248, 1))
-                // Restore the free memory pointer.
-                mstore(0x40, ptr)
+                // calling address(this).localize(bytes32,bytes32)
+                // eventually calling PreimageKeyLib.localize(bytes32,bytes32)
+                let memPtr := mload(0x40) // get pointer to free memory for preimage interactions
+                mstore(memPtr, shl(224, 0x1aae47f0)) // (32-4)*8=224: right-pad the function selector, and then store it as prefix
+                mstore(add(memPtr, 0x04), preImageKey)
+                mstore(add(memPtr, 0x24), localContext_)
+                let cgas := 100000 // TODO change call gas
+
+                // use delegatecall to follow same behavior with library method call
+                let res := delegatecall(cgas, address(), memPtr, 0x44, 0x00, 0x20) // output into scratch space
+                if res {
+                    // 1 on success
+                    localizedKey := mload(0x00)
+                    leave
+                }
+                revertWithCode(0xbadf00d0)
             }
 
             function readPreimageValue(addr, count, localContext_) -> out {

--- a/rvsol/test/Step.t.sol
+++ b/rvsol/test/Step.t.sol
@@ -1,0 +1,18 @@
+pragma solidity 0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+import {Step} from "src/Step.sol";
+import {PreimageOracle} from "@optimism/packages/contracts-bedrock/src/cannon/PreimageOracle.sol";
+
+contract Step_Test is Test {
+    PreimageOracle internal oracle;
+    Step internal step;
+
+    function setUp() public {
+        oracle = new PreimageOracle(0, 0, 0);
+        step = new Step(oracle);
+        vm.store(address(step), 0x0, bytes32(abi.encode(address(oracle))));
+        vm.label(address(oracle), "PreimageOracle");
+        vm.label(address(step), "MIPS");
+    }
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Upstream cannon [directly embeds](https://github.com/ethereum-optimism/optimism/blob/0ca5a5397023b466c166e213ba2b303a9fd97f51/packages/contracts-bedrock/src/cannon/MIPS.sol#L206) `PreimageKeyLib` methods to its step contract. By including library functions(which only holds internal methods), bytecodes of `localize` method will be stored in step contract and called by `JUMP` instruction.

In asterisc's case, this change is nontrivial because entire `Step` method is implemented in yul. Previous PRs relied on duplication of implementation inside of STF code.

I found a workaround; define wrapper method which calls `localize` method from the library. The compiler thinks this method is not used by anywhere when it is not declared as public method, so explicitly mark as public. After that, delegatecall the method, to preserve `msg.sender`.

However after finding this approach, It feels like it is overly complicated. Should we allow duplications and copy-paste `localize` implementation, by closing this PR?

Is there any better method while deduplication?

**Tests**

EVM mode tests will cover this diff.

**Additional context**

Current dependencies on/for this PR:
- master
    - **PR** https://github.com/ethereum-optimism/asterisc/pull/13
        - **PR** https://github.com/ethereum-optimism/asterisc/pull/12 (this PR)