### PR TITLE
feat: Rename `Step.sol` to `RISCV.sol`

### DIFF
--- a/rvgo/test/evm_test.go
+++ b/rvgo/test/evm_test.go
@@ -54,8 +54,8 @@ func fakeHeader(n uint64, parentHash common.Hash) *types.Header {
 	return &header
 }
 
-func loadStepContractCode(t *testing.T) *Contract {
-	dat, err := os.ReadFile("../../rvsol/out/Step.sol/Step.json")
+func loadRISCVContractCode(t *testing.T) *Contract {
+	dat, err := os.ReadFile("../../rvsol/out/RISCV.sol/RISCV.json")
 	require.NoError(t, err)
 	var outDat Contract
 	err = json.Unmarshal(dat, &outDat)
@@ -125,7 +125,7 @@ var testAddrs = &Addresses{
 
 func testContracts(t *testing.T) *Contracts {
 	return &Contracts{
-		RISCV:  loadStepContractCode(t),
+		RISCV:  loadRISCVContractCode(t),
 		Oracle: loadPreimageOracleContractCode(t),
 	}
 }
@@ -133,7 +133,7 @@ func testContracts(t *testing.T) *Contracts {
 func addTracer(t *testing.T, env *vm.EVM, addrs *Addresses, contracts *Contracts) {
 	//env.Config.Tracer = logger.NewMarkdownLogger(&logger.Config{}, os.Stdout)
 
-	a, err := contracts.RISCV.SourceMap([]string{"../../rvsol/src/Step.sol"})
+	a, err := contracts.RISCV.SourceMap([]string{"../../rvsol/src/RISCV.sol"})
 	require.NoError(t, err)
 	b, err := contracts.Oracle.SourceMap([]string{"../../rvsol/src/PreimageOracle.sol"})
 	require.NoError(t, err)

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import {IPreimageOracle} from "@optimism/src/cannon/interfaces/IPreimageOracle.sol";
 
-contract Step {
+contract RISCV {
 
     IPreimageOracle public preimageOracle;
 

--- a/rvsol/test/RISCV.t.sol
+++ b/rvsol/test/RISCV.t.sol
@@ -1,18 +1,18 @@
 pragma solidity 0.8.15;
 
 import {Test} from "forge-std/Test.sol";
-import {Step} from "src/Step.sol";
+import {RISCV} from "src/RISCV.sol";
 import {PreimageOracle} from "@optimism/src/cannon/PreimageOracle.sol";
 
-contract Step_Test is Test {
+contract RISCV_Test is Test {
+    RISCV internal riscv;
     PreimageOracle internal oracle;
-    Step internal step;
 
     function setUp() public {
         oracle = new PreimageOracle(0, 0, 0);
-        step = new Step(oracle);
-        vm.store(address(step), 0x0, bytes32(abi.encode(address(oracle))));
+        riscv = new RISCV(oracle);
+        vm.store(address(riscv), 0x0, bytes32(abi.encode(address(oracle))));
         vm.label(address(oracle), "PreimageOracle");
-        vm.label(address(step), "Step");
+        vm.label(address(riscv), "RISCV");
     }
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Upstream cannon uses step contract name following its architecture: `MIPS.sol`. Currently asterisc uses step contract name as `Step.sol`. Rename `Step.sol` to `RISCV.sol` for consistency.

**Tests**

None

**Additional context**

Current dependencies on/for this PR:
- master
    - **PR** https://github.com/ethereum-optimism/asterisc/pull/13 
        - **PR** https://github.com/ethereum-optimism/asterisc/pull/14 (this PR)