### PR TITLE
feat: Support metadata for symbol lookup

### DIFF
--- a/rvgo/cmd/load_elf.go
+++ b/rvgo/cmd/load_elf.go
@@ -27,6 +27,13 @@ func LoadELF(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to patch VM")
 	}
+	meta, err := MakeMetadata(elfProgram)
+	if err != nil {
+		return fmt.Errorf("failed to compute program metadata: %w", err)
+	}
+	if err := jsonutil.WriteJSON[*Metadata](ctx.Path(cannon.LoadELFMetaFlag.Name), meta, OutFilePerm); err != nil {
+		return fmt.Errorf("failed to output metadata: %w", err)
+	}
 	return jsonutil.WriteJSON[*fast.VMState](ctx.Path(cannon.LoadELFOutFlag.Name), state, OutFilePerm)
 }
 
@@ -38,5 +45,6 @@ var LoadELFCommand = &cli.Command{
 	Flags: []cli.Flag{
 		cannon.LoadELFPathFlag,
 		cannon.LoadELFOutFlag,
+		cannon.LoadELFMetaFlag,
 	},
 }

--- a/rvgo/cmd/metadata.go
+++ b/rvgo/cmd/metadata.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"debug/elf"
+	"fmt"
+	"sort"
+)
+
+type Symbol struct {
+	Name  string `json:"name"`
+	Start uint64 `json:"start"`
+	Size  uint64 `json:"size"`
+}
+
+type Metadata struct {
+	Symbols []Symbol `json:"symbols"`
+}
+
+func MakeMetadata(elfProgram *elf.File) (*Metadata, error) {
+	syms, err := elfProgram.Symbols()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load symbols table: %w", err)
+	}
+	// Make sure the table is sorted, Go outputs mostly sorted data, except some internal functions
+	sort.Slice(syms, func(i, j int) bool {
+		return syms[i].Value < syms[j].Value
+	})
+	out := &Metadata{Symbols: make([]Symbol, len(syms))}
+	for i, s := range syms {
+		out.Symbols[i] = Symbol{Name: s.Name, Start: s.Value, Size: s.Size}
+	}
+	return out, nil
+}
+
+func (m *Metadata) LookupSymbol(addr uint64) string {
+	if len(m.Symbols) == 0 {
+		return "!unknown"
+	}
+	// find first symbol with higher start. Or n if no such symbol exists
+	i := sort.Search(len(m.Symbols), func(i int) bool {
+		return m.Symbols[i].Start > addr
+	})
+	if i == 0 {
+		return "!start"
+	}
+	out := &m.Symbols[i-1]
+	if out.Start+out.Size < addr { // addr may be pointing to a gap between symbols
+		return "!gap"
+	}
+	return out.Name
+}
+
+func (m *Metadata) SymbolMatcher(name string) func(addr uint64) bool {
+	for _, s := range m.Symbols {
+		if s.Name == name {
+			start := s.Start
+			end := s.Start + s.Size
+			return func(addr uint64) bool {
+				return addr >= start && addr < end
+			}
+		}
+	}
+	return func(addr uint64) bool {
+		return false
+	}
+}

--- a/rvgo/cmd/process_preimage_oracle.go
+++ b/rvgo/cmd/process_preimage_oracle.go
@@ -85,10 +85,6 @@ func (p *ProcessPreimageOracle) GetPreimage(k [32]byte) []byte {
 	return p.pCl.Get(rawKey(k))
 }
 
-func (p *ProcessPreimageOracle) GetCmd() *exec.Cmd {
-	return p.cmd
-}
-
 func (p *ProcessPreimageOracle) Start() error {
 	if p.cmd == nil {
 		return nil

--- a/rvgo/cmd/run.go
+++ b/rvgo/cmd/run.go
@@ -134,9 +134,8 @@ func Run(ctx *cli.Context) error {
 	snapshotFmt := ctx.String(cannon.RunSnapshotFmtFlag.Name)
 
 	stepFn := us.Step
-	poCmd := po.GetCmd()
-	if poCmd != nil {
-		stepFn = Guard(poCmd.ProcessState, stepFn)
+	if po.cmd != nil {
+		stepFn = Guard(po.cmd.ProcessState, stepFn)
 	}
 
 	start := time.Now()


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- Bring the missing utility feature [`Metadata`](https://github.com/ethereum-optimism/optimism/blob/develop/cannon/mipsevm/metadata.go) from Cannon.
- Small fix for `ProcessPreimageOracle`: Remove an unnecessary method.