### PR TITLE
Fix for running op-program

### DIFF
--- a/docs/golang.md
+++ b/docs/golang.md
@@ -141,6 +141,21 @@ SYS_sched_getaffinity	123
 # program advises kernel how to use memory, can be no-op
 SYS_madvise		233
 
+# NOOP - To not support, but needed to run op-program
+# May need more investigation
+# -----------------------
+# file memory mapping
+SYS_munmap		215
+
+# interprocess communication
+SYS_pipe2		59
+
+SYS_epoll_create1       20
+SYS_epoll_ctl           21
+SYS_readlinkat          78
+SYS_newfstatat          79
+SYS_newuname            160
+SYS_getrandom           278
 
 # To not support
 # -----------------------
@@ -152,12 +167,6 @@ SYS_socket		198
 SYS_close		57
 SYS_openat		56
 SYS_faccessat		48
-
-# file memory mapping
-SYS_munmap		215
-
-# interprocess communication
-SYS_pipe2		59
 
 # send a signal to another process
 SYS_kill		129

--- a/rvgo/fast/elf.go
+++ b/rvgo/fast/elf.go
@@ -69,6 +69,16 @@ func PatchVM(f *elf.File, vmState *VMState) error {
 			"runtime.main.func1",        // patch out: main.func() { newm(sysmon, ....) }
 			"runtime.deductSweepCredit", // uses floating point nums and interacts with gc we disabled
 			"runtime.(*gcControllerState).commit",
+			// these prometheus packages rely on concurrent background things. We cannot run those.
+			"github.com/prometheus/client_golang/prometheus.init",
+			"github.com/prometheus/client_golang/prometheus.init.0",
+			"github.com/prometheus/procfs.init",
+			"github.com/prometheus/common/model.init",
+			"github.com/prometheus/client_model/go.init",
+			"github.com/prometheus/client_model/go.init.0",
+			"github.com/prometheus/client_model/go.init.1",
+			// skip flag pkg init, we need to debug arg-processing more to see why this fails
+			"flag.init",
 			// We need to patch this out, we don't pass float64nan because we don't support floats
 			"runtime.check":
 			// RISCV patch: ret (pseudo instruction)

--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -554,6 +554,9 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 		case 160: // newuname - ignored
 			setRegister(toU64(10), toU64(0))
 			setRegister(toU64(11), toU64(0))
+		case 215: // munmap - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
 		case 278: // getrandom - ignored
 			setRegister(toU64(10), toU64(0))
 			setRegister(toU64(11), toU64(0))

--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -536,6 +536,27 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 		case 233: // madvise - ignored
 			setRegister(toU64(10), toU64(0))
 			setRegister(toU64(11), toU64(0))
+		case 20: // epoll_create1 - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 21: // epoll_ctl - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 59: // pipe2 - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 78: // readlinkat - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 79: // newfstatat - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 160: // newuname - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 278: // getrandom - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
 		case 261: // prlimit64 -- unsupported, we have getrlimit, is prlimit64 even called?
 			revertWithCode(0xf001ca11, fmt.Errorf("unsupported system call: %d", a7))
 		case 422: // futex - not supported, for now

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -734,6 +734,9 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		case 160: // newuname - ignored
 			setRegister(toU64(10), toU64(0))
 			setRegister(toU64(11), toU64(0))
+		case 215: // munmap - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
 		case 278: // getrandom - ignored
 			setRegister(toU64(10), toU64(0))
 			setRegister(toU64(11), toU64(0))

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -716,6 +716,27 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		case 233: // madvise - ignored
 			setRegister(toU64(10), toU64(0))
 			setRegister(toU64(11), toU64(0))
+		case 20: // epoll_create1 - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 21: // epoll_ctl - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 59: // pipe2 - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 78: // readlinkat - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 79: // newfstatat - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 160: // newuname - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
+		case 278: // getrandom - ignored
+			setRegister(toU64(10), toU64(0))
+			setRegister(toU64(11), toU64(0))
 		case 261: // prlimit64 -- unsupported, we have getrlimit, is prlimit64 even called?
 			revertWithCode(0xf001ca11, fmt.Errorf("unsupported system call: %d", a7))
 		case 422: // futex - not supported, for now

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1020,6 +1020,9 @@ contract RISCV {
                 } case 160 { // newuname - ignored
                     setRegister(toU64(10), toU64(0))
                     setRegister(toU64(11), toU64(0))
+                } case 215 { // munmap - ignored
+                    setRegister(toU64(10), toU64(0))
+                    setRegister(toU64(11), toU64(0))
                 } case 278 { // getrandom - ignored
                     setRegister(toU64(10), toU64(0))
                     setRegister(toU64(11), toU64(0))

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1002,6 +1002,27 @@ contract RISCV {
                 } case 233 { // madvise - ignored
                     setRegister(toU64(10), toU64(0))
                     setRegister(toU64(11), toU64(0))
+                } case 20 { // epoll_create1 - ignored
+                    setRegister(toU64(10), toU64(0))
+                    setRegister(toU64(11), toU64(0))
+                } case 21 { // epoll_ctl - ignored
+                    setRegister(toU64(10), toU64(0))
+                    setRegister(toU64(11), toU64(0))
+                } case 59 { // pipe2 - ignored
+                    setRegister(toU64(10), toU64(0))
+                    setRegister(toU64(11), toU64(0))
+                } case 78 { // readlinkat - ignored
+                    setRegister(toU64(10), toU64(0))
+                    setRegister(toU64(11), toU64(0))
+                } case 79 { // newfstatat - ignored
+                    setRegister(toU64(10), toU64(0))
+                    setRegister(toU64(11), toU64(0))
+                } case 160 { // newuname - ignored
+                    setRegister(toU64(10), toU64(0))
+                    setRegister(toU64(11), toU64(0))
+                } case 278 { // getrandom - ignored
+                    setRegister(toU64(10), toU64(0))
+                    setRegister(toU64(11), toU64(0))
                 } case 261 { // prlimit64 -- unsupported, we have getrlimit, is prlimit64 even called?
                     revertWithCode(0xf001ca11) // unsupported system call
                 } case 422 { // futex - not supported, for now

--- a/tests/go-tests/Makefile
+++ b/tests/go-tests/Makefile
@@ -4,13 +4,13 @@ bin:
 	mkdir bin
 
 bin/simple:
-	cd simple && GOOS=linux GOARCH=riscv64 GOROOT=$(LATEST_GOROOT) go build -o ../bin/simple .
+	cd simple && GOOS=linux GOARCH=riscv64 GOROOT=$(LATEST_GOROOT) go build -gcflags="all=-d=softfloat" -o ../bin/simple .
 
 bin/simple.dump: bin/simple
 	riscv64-linux-gnu-objdump -D --disassemble --disassembler-options=no-aliases --wide --source -m riscv:rv64 -EL bin/simple > bin/simple.dump
 
 bin/minimal:
-	cd minimal && GOOS=linux GOARCH=riscv64 GOROOT=$(LATEST_GOROOT) go build -o ../bin/minimal .
+	cd minimal && GOOS=linux GOARCH=riscv64 GOROOT=$(LATEST_GOROOT) go build -gcflags="all=-d=softfloat" -o ../bin/minimal .
 
 bin/minimal.dump: bin/minimal
 	riscv64-linux-gnu-objdump -D --disassemble --disassembler-options=no-aliases --wide --source -m riscv:rv64 -EL bin/minimal > bin/minimal.dump


### PR DESCRIPTION
**Description**

- Patch more symbols (referenced from Cannon)
- Ignore unnecessary system calls
  - `epoll_create1`
  - `epoll_ctl`
  - `pipe2`
  - `readlinkat`
  - `newfstatat`
  - `newuname`
  - `munmap`
  - `getrandom`
  - TODO: is it ok?
- Add softfloat gcflag

**Test**
Manually run op-program(v.1.5.1) by `run` command on the local devnet and op-sepolia, and it works :)