### PR TITLE
feat: Asterisc contracts VM tests - FFI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.x'
+      - name: Build FFI
+        run: go build
+        working-directory: rvgo/scripts/go-ffi
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run foundry tests
-        run: forge test -vvv
+        run: forge test -vvv --ffi
         working-directory: rvsol
 
   # go-lint:

--- a/rvgo/scripts/go-ffi/bin.go
+++ b/rvgo/scripts/go-ffi/bin.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("Must pass a subcommand")
+	}
+	switch os.Args[1] {
+	case "diff":
+		DiffTestUtils()
+	default:
+		log.Fatalf("Unrecognized subcommand: %s", os.Args[1])
+	}
+}

--- a/rvgo/scripts/go-ffi/differential-testing.go
+++ b/rvgo/scripts/go-ffi/differential-testing.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum-optimism/asterisc/rvgo/fast"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// ABI types
+var (
+	asteriscMemoryProof, _ = abi.NewType("tuple", "AsteriscMemoryProof", []abi.ArgumentMarshaling{
+		{Name: "memRoot", Type: "bytes32"},
+		{Name: "proof", Type: "bytes"},
+	})
+	asteriscMemoryProofArgs = abi.Arguments{
+		{Name: "encodedAsteriscMemoryProof", Type: asteriscMemoryProof},
+	}
+)
+
+func DiffTestUtils() {
+	args := os.Args[2:]
+	variant := args[0]
+
+	// This command requires arguments
+	if len(args) == 0 {
+		panic("Error: No arguments provided")
+	}
+
+	switch variant {
+	case "asteriscMemoryProof":
+		// <pc, insn, [memAddr, memValue]>
+		if len(args) != 3 && len(args) != 5 {
+			panic("Error: asteriscMemoryProofWithProof requires 2 or 4 arguments")
+		}
+		mem := fast.NewMemory()
+		pc, err := strconv.ParseUint(args[1], 10, 64)
+		checkErr(err, "Error decoding addr")
+		insn, err := strconv.ParseUint(args[2], 10, 32)
+		checkErr(err, "Error decoding insn")
+		instBytes := make([]byte, 4)
+		binary.LittleEndian.PutUint32(instBytes, uint32(insn))
+		mem.SetUnaligned(uint64(pc), instBytes)
+
+		// proof size: 64-5+1=60 (a 64-bit mem-address branch to 32 byte leaf, incl leaf itself), all 32 bytes
+		// 60 * 32 = 1920
+		var insnProof, memProof [1920]byte
+		if len(args) == 5 {
+			memAddr, err := strconv.ParseUint(args[3], 10, 64)
+			checkErr(err, "Error decoding memAddr")
+			memValue, err := hex.DecodeString(strings.TrimPrefix(args[4], "0x"))
+			checkErr(err, "Error decoding memValue")
+			mem.SetUnaligned(uint64(memAddr), memValue)
+			memProof = mem.MerkleProof(uint64(memAddr))
+		}
+		insnProof = mem.MerkleProof(uint64(pc))
+
+		output := struct {
+			MemRoot common.Hash
+			Proof   []byte
+		}{
+			MemRoot: mem.MerkleRoot(),
+			Proof:   append(insnProof[:], memProof[:]...),
+		}
+		packed, err := asteriscMemoryProofArgs.Pack(&output)
+		checkErr(err, "Error encoding output")
+		fmt.Print(hexutil.Encode(packed[32:]))
+	default:
+		panic(fmt.Errorf("unknown command: %s", args[0]))
+	}
+}

--- a/rvgo/scripts/go-ffi/utils.go
+++ b/rvgo/scripts/go-ffi/utils.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+// checkErr checks if err is not nil, and throws if so.
+// Shorthand to ease go's god awful error handling
+// from https://github.com/ethereum-optimism/optimism/blob/5bd1f4633195411b93d292f7b34e2565da7b773e/packages/contracts-bedrock/scripts/differential-testing/utils.go
+func checkErr(err error, failReason string) {
+	if err != nil {
+		panic(fmt.Errorf("%s: %w", failReason, err))
+	}
+}

--- a/rvsol/test/CommonTest.sol
+++ b/rvsol/test/CommonTest.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+/// @title FFIInterface
+/// @notice This contract is set into state using `etch` and therefore must not have constructor logic.
+///         It also MUST be compiled with `0.8.15` because `vm.getDeployedCode` will break if there
+///         are multiple artifacts for different compiler versions.
+contract FFIInterface {
+    Vm internal constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    function getAsteriscMemoryProof(uint64 pc, uint32 insn) external returns (bytes32, bytes memory) {
+        string[] memory cmds = new string[](5);
+        cmds[0] = "../rvgo/scripts/go-ffi/go-ffi";
+        cmds[1] = "diff";
+        cmds[2] = "asteriscMemoryProof";
+        cmds[3] = vm.toString(pc);
+        cmds[4] = vm.toString(insn);
+        bytes memory result = vm.ffi(cmds);
+        (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
+        return (memRoot, proof);
+    }
+
+    function getAsteriscMemoryProof(uint64 pc, uint32 insn, uint64 memAddr, bytes32 memVal)
+        external
+        returns (bytes32, bytes memory)
+    {
+        string[] memory cmds = new string[](7);
+        cmds[0] = "../rvgo/scripts/go-ffi/go-ffi";
+        cmds[1] = "diff";
+        cmds[2] = "asteriscMemoryProof";
+        cmds[3] = vm.toString(pc);
+        cmds[4] = vm.toString(insn);
+        cmds[5] = vm.toString(memAddr);
+        cmds[6] = vm.toString(memVal); // 0x prefixed hex string
+        bytes memory result = vm.ffi(cmds);
+        (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
+        return (memRoot, proof);
+    }
+}
+
+/// @title CommonTest
+/// @dev An extension to `Test` that sets up the optimism smart contracts.
+contract CommonTest is Test {
+    FFIInterface constant ffi = FFIInterface(address(uint160(uint256(keccak256(abi.encode("optimism.ffi"))))));
+
+    function setUp() public virtual {
+        vm.etch(address(ffi), vm.getDeployedCode("CommonTest.sol:FFIInterface"));
+        vm.label(address(ffi), "FFIInterface");
+    }
+}

--- a/rvsol/test/RISCV.t.sol
+++ b/rvsol/test/RISCV.t.sol
@@ -62,7 +62,7 @@ contract RISCV_Test is CommonTest {
 
     function test_add_succeeds() public {
         uint32 insn = encodeRType(0x33, 1, 0, 2, 3, 0); // add x1, x2, x3
-        (State memory state, bytes memory proof) = constructRISCVState(0, insn, 0x4, 0);
+        (State memory state, bytes memory proof) = constructRISCVState(0, insn);
         state.registers[2] = 0x3030;
         state.registers[3] = 0x3131;
         bytes memory encodedState = encodeState(state);
@@ -131,6 +131,11 @@ contract RISCV_Test is CommonTest {
         returns (State memory state, bytes memory proof)
     {
         (state.memRoot, proof) = ffi.getAsteriscMemoryProof(pc, insn, addr, val);
+        state.pc = pc;
+    }
+
+    function constructRISCVState(uint64 pc, uint32 insn) internal returns (State memory state, bytes memory proof) {
+        (state.memRoot, proof) = ffi.getAsteriscMemoryProof(pc, insn);
         state.pc = pc;
     }
 

--- a/rvsol/test/RISCV.t.sol
+++ b/rvsol/test/RISCV.t.sol
@@ -3,8 +3,12 @@ pragma solidity 0.8.15;
 import {Test} from "forge-std/Test.sol";
 import {RISCV} from "src/RISCV.sol";
 import {PreimageOracle} from "@optimism/src/cannon/PreimageOracle.sol";
+import {CommonTest} from "./CommonTest.sol";
+// FIXME: somehow this import gives a multiple declaration error
+// This import is for the VMStatus
+// import "@optimism/src/libraries/DisputeTypes.sol";
 
-contract RISCV_Test is Test {
+contract RISCV_Test is CommonTest {
     /// @notice Stores the VM state.
     ///         Total state size: 32 + 32 + 8 * 2 + 1 * 2 + 8 * 3 + 32 * 8 = 362 bytes
     ///         Note that struct is not used for step execution and used only for testing
@@ -25,7 +29,8 @@ contract RISCV_Test is Test {
     RISCV internal riscv;
     PreimageOracle internal oracle;
 
-    function setUp() public {
+    function setUp() public virtual override {
+        super.setUp();
         oracle = new PreimageOracle(0, 0, 0);
         riscv = new RISCV(oracle);
         vm.store(address(riscv), 0x0, bytes32(abi.encode(address(oracle))));
@@ -55,6 +60,25 @@ contract RISCV_Test is Test {
         assertTrue(postState != bytes32(0));
     }
 
+    function test_add_succeeds() public {
+        uint32 insn = encodeRType(0x33, 1, 0, 2, 3, 0); // add x1, x2, x3
+        (State memory state, bytes memory proof) = constructRISCVState(0, insn, 0x4, 0);
+        state.registers[2] = 0x3030;
+        state.registers[3] = 0x3131;
+        bytes memory encodedState = encodeState(state);
+
+        State memory expect;
+        expect.memRoot = state.memRoot;
+        expect.pc = state.pc + 4;
+        expect.step = state.step + 1;
+        expect.registers[1] = state.registers[2] + state.registers[3];
+        expect.registers[2] = state.registers[2];
+        expect.registers[3] = state.registers[3];
+
+        bytes32 postState = riscv.step(encodedState, proof, 0);
+        assertEq(postState, outputState(expect), "unexpected post state");
+    }
+
     function encodeState(State memory state) internal pure returns (bytes memory) {
         bytes memory registers;
         for (uint256 i = 0; i < state.registers.length; i++) {
@@ -73,5 +97,55 @@ contract RISCV_Test is Test {
             registers
         );
         return stateData;
+    }
+
+    /// @dev RISCV VM status codes:
+    ///      0. Exited with success (Valid)
+    ///      1. Exited with success (Invalid)
+    ///      2. Exited with failure (Panic)
+    ///      3. Unfinished
+    // TODO: import DisputeTypes.sol. For some reason, import is not working
+    function vmStatus(State memory state) internal pure returns (uint8 out_) {
+        if (!state.exited) {
+            return 3; // VMStatuses.UNFINISHED
+        } else if (state.exitCode == 0) {
+            return 0; // VMStatuses.VALID
+        } else if (state.exitCode == 1) {
+            return 1; // VMStatuses.INVALID
+        } else {
+            return 2; // VMStatuses.PANIC
+        }
+    }
+
+    function outputState(State memory state) internal pure returns (bytes32 out_) {
+        bytes memory enc = encodeState(state);
+        uint8 status = vmStatus(state);
+        assembly {
+            out_ := keccak256(add(enc, 0x20), 362)
+            out_ := or(and(not(shl(248, 0xFF)), out_), shl(248, status))
+        }
+    }
+
+    function constructRISCVState(uint64 pc, uint32 insn, uint64 addr, bytes32 val)
+        internal
+        returns (State memory state, bytes memory proof)
+    {
+        (state.memRoot, proof) = ffi.getAsteriscMemoryProof(pc, insn, addr, val);
+        state.pc = pc;
+    }
+
+    function encodeRType(uint8 opcode, uint8 rd, uint8 funct3, uint8 rs1, uint8 rs2, uint8 funct7)
+        internal
+        pure
+        returns (uint32 insn)
+    {
+        // insn := [funct7] | [rs2] | [rs1] | [funct3] | [rd]  | [opcode]
+        // example: 0000000 | 00011 | 00010 | 000      | 00001 | 0110011
+        insn = uint32(funct7 & 0x7F) << (7 + 5 + 3 + 5 + 5);
+        insn |= uint32(rs2 & 0x1F) << (7 + 5 + 3 + 5);
+        insn |= uint32(rs1 & 0x1F) << (7 + 5 + 3);
+        insn |= uint32(funct3 & 0x7) << (7 + 5);
+        insn |= uint32(rd & 0x1F) << 7;
+        insn |= uint32(opcode & 0x7F);
     }
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Implements FFI interface for fetching snapshot data on foundry testing. Subset of https://github.com/ethereum-optimism/optimism/pull/6638. 

For unknown reason, importing `@optimism/src/libraries/DisputeTypes.sol` causes below build error.
```
Error: 
Compiler run failed:
Error (2333): Identifier already declared.
 --> lib/optimism/packages/contracts-bedrock/src/dispute/lib/LibGameId.sol:9:1:
  |
9 | library LibGameId {
  | ^ (Relevant source part starts here and spans across multiple lines).
Note: The previous declaration is here:
 --> lib/optimism/packages/contracts-bedrock/src/dispute/lib/LibGameId.sol:4:1:
  |
4 | import "src/libraries/DisputeTypes.sol";
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
I could not resolve this, so first hardcoded the `VMStatuses` for temporary solution. Will try to remove this in the follow up PR.

**Tests**

Added a minimal viable test which only tests `add` RISCV instruction: `test_add_succeeds`. Tests for instruction and syscalls will be added in followup PR.

**Additional context**

Current dependencies on/for this PR:
- master
    - **PR** https://github.com/ethereum-optimism/asterisc/pull/20 (this PR)
        - **PR** https://github.com/ethereum-optimism/asterisc/pull/22 
