### PR TITLE
More syscall fuzz test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,17 +27,35 @@ test: build
 
 fuzz: build
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallExit ./rvgo/test
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallBrk ./rvgo/test
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallMmap ./rvgo/test
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallFcntl ./rvgo/test
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallOpenat ./rvgo/test
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallClockGettime ./rvgo/test
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallClone ./rvgo/test
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallGetrlimit ./rvgo/test
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallNoop ./rvgo/test
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateRead ./rvgo/test
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateHintRead ./rvgo/test
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStatePreimageRead ./rvgo/test
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateWrite ./rvgo/test
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateHintWrite ./rvgo/test
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStatePreimageWrite ./rvgo/test
 
 fuzz-mac:
 	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallExit ./rvgo/test
+	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallBrk ./rvgo/test
+	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallMmap ./rvgo/test
+	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallFcntl ./rvgo/test
+	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallOpenat ./rvgo/test
+	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallClockGettime ./rvgo/test
+	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallClone ./rvgo/test
+	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallGetrlimit ./rvgo/test
 	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallNoop ./rvgo/test
+	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateRead ./rvgo/test
 	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateHintRead ./rvgo/test
 	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStatePreimageRead ./rvgo/test
+	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateWrite ./rvgo/test
 	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateHintWrite ./rvgo/test
 	go test -ldflags=-extldflags=-Wl,-ld_classic -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStatePreimageWrite ./rvgo/test
 

--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -535,6 +535,8 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 				// first 8 bytes: soft limit. 1024 file handles max open
 				// second 8 bytes: hard limit
 				storeMemUnaligned(addr, toU64(16), or(shortToU256(1024), shl(toU256(64), shortToU256(1024))), 1, 2, true, true)
+				setRegister(toU64(10), toU64(0))
+				setRegister(toU64(11), toU64(0))
 			default:
 				revertWithCode(0xf0012, fmt.Errorf("unrecognized resource limit lookup: %d", res))
 			}

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -710,6 +710,8 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 				// first 8 bytes: soft limit. 1024 file handles max open
 				// second 8 bytes: hard limit
 				storeMemUnaligned(addr, toU64(16), or(shortToU256(1024), shl(toU256(64), shortToU256(1024))), 1, 2)
+				setRegister(toU64(10), toU64(0))
+				setRegister(toU64(11), toU64(0))
 			default:
 				revertWithCode(0xf0012, fmt.Errorf("unrecognized resource limit lookup: %d", res))
 			}

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -138,7 +138,7 @@ func FuzzStateSyscallBrk(f *testing.F) {
 			Exited:          false,
 			Memory:          fast.NewMemory(),
 			LoadReservation: 0,
-			Registers:       [32]uint64{17: fast.SysBrk},
+			Registers:       [32]uint64{17: riscv.SysBrk},
 			Step:            step,
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
@@ -183,7 +183,7 @@ func FuzzStateSyscallMmap(f *testing.F) {
 			Exited:          false,
 			Memory:          fast.NewMemory(),
 			LoadReservation: 0,
-			Registers:       [32]uint64{17: fast.SysMmap, 10: addr, 11: length},
+			Registers:       [32]uint64{17: riscv.SysMmap, 10: addr, 11: length},
 			Step:            step,
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
@@ -234,7 +234,7 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 			Exited:          false,
 			Memory:          fast.NewMemory(),
 			LoadReservation: 0,
-			Registers:       [32]uint64{17: fast.SysFcntl, 10: fd, 11: cmd},
+			Registers:       [32]uint64{17: riscv.SysFcntl, 10: fd, 11: cmd},
 			Step:            step,
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
@@ -297,7 +297,7 @@ func FuzzStateSyscallOpenat(f *testing.F) {
 			Exited:          false,
 			Memory:          fast.NewMemory(),
 			LoadReservation: 0,
-			Registers:       [32]uint64{17: fast.SysOpenat},
+			Registers:       [32]uint64{17: riscv.SysOpenat},
 			Step:            step,
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
@@ -340,7 +340,7 @@ func FuzzStateSyscallClockGettime(f *testing.F) {
 			Exited:          false,
 			Memory:          fast.NewMemory(),
 			LoadReservation: 0,
-			Registers:       [32]uint64{17: fast.SysClockGettime, 11: addr},
+			Registers:       [32]uint64{17: riscv.SysClockGettime, 11: addr},
 			Step:            step,
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
@@ -387,7 +387,7 @@ func FuzzStateSyscallClone(f *testing.F) {
 			Exited:          false,
 			Memory:          fast.NewMemory(),
 			LoadReservation: 0,
-			Registers:       [32]uint64{17: fast.SysClone},
+			Registers:       [32]uint64{17: riscv.SysClone},
 			Step:            step,
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
@@ -430,7 +430,7 @@ func FuzzStateSyscallGetrlimit(f *testing.F) {
 			Exited:          false,
 			Memory:          fast.NewMemory(),
 			LoadReservation: 0,
-			Registers:       [32]uint64{17: fast.SysGetrlimit, 10: 7, 11: addr},
+			Registers:       [32]uint64{17: riscv.SysGetrlimit, 10: 7, 11: addr},
 			Step:            step,
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
@@ -474,7 +474,7 @@ func FuzzStateSyscallGetrlimit(f *testing.F) {
 			Exited:          false,
 			Memory:          fast.NewMemory(),
 			LoadReservation: 0,
-			Registers:       [32]uint64{17: fast.SysGetrlimit, 10: res, 11: addr},
+			Registers:       [32]uint64{17: riscv.SysGetrlimit, 10: res, 11: addr},
 			Step:            0,
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
@@ -576,7 +576,7 @@ func FuzzStateSyscallRead(f *testing.F) {
 			Exited:          false,
 			Memory:          fast.NewMemory(),
 			LoadReservation: 0,
-			Registers:       [32]uint64{17: fast.SysRead, 10: fd, 11: addr, 12: count},
+			Registers:       [32]uint64{17: riscv.SysRead, 10: fd, 11: addr, 12: count},
 			Step:            step,
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
@@ -606,10 +606,10 @@ func FuzzStateSyscallRead(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, fd, addr, count, pc, step uint64) {
 		// Test stdin
-		testRead(t, fast.FdStdin, addr, count, pc, step, 0, 0)
+		testRead(t, riscv.FdStdin, addr, count, pc, step, 0, 0)
 
 		// Test EBADF err
-		if fd == fast.FdStdin || fd == fast.FdHintRead || fd == fast.FdPreimageRead {
+		if fd == riscv.FdStdin || fd == riscv.FdHintRead || fd == riscv.FdPreimageRead {
 			// Ensure unsupported fd
 			fd += 1
 		}
@@ -749,7 +749,7 @@ func FuzzStateSyscallWrite(f *testing.F) {
 			Exited:          false,
 			Memory:          fast.NewMemory(),
 			LoadReservation: 0,
-			Registers:       [32]uint64{17: fast.SysWrite, 10: fd, 11: addr, 12: count},
+			Registers:       [32]uint64{17: riscv.SysWrite, 10: fd, 11: addr, 12: count},
 			Step:            step,
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
@@ -779,13 +779,13 @@ func FuzzStateSyscallWrite(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, fd, addr, count, pc, step uint64) {
 		// Test stdout
-		testWrite(t, fast.FdStdout, addr, count, pc, step, count, 0)
+		testWrite(t, riscv.FdStdout, addr, count, pc, step, count, 0)
 
 		// Test stderr
-		testWrite(t, fast.FdStderr, addr, count, pc, step, count, 0)
+		testWrite(t, riscv.FdStderr, addr, count, pc, step, count, 0)
 
 		// Test EBADF err
-		if fd == fast.FdStdout || fd == fast.FdStderr || fd == fast.FdHintWrite || fd == fast.FdPreimageWrite {
+		if fd == riscv.FdStdout || fd == riscv.FdStderr || fd == riscv.FdHintWrite || fd == riscv.FdPreimageWrite {
 			// Ensure unsupported fd
 			fd += 6
 		}

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -482,6 +482,7 @@ func FuzzStateSyscallGetrlimit(f *testing.F) {
 		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
 		_, err := fastState.Step(true)
 		require.Contains(t, err.Error(), "f0012")
+		// TODO: Test EVM & slow VM
 	}
 
 	f.Fuzz(func(t *testing.T, res, addr, pc, step uint64) {

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"encoding/binary"
 	"fmt"
 	"os"
 	"testing"
@@ -124,6 +125,378 @@ func FuzzStateSyscallExit(f *testing.F) {
 	})
 }
 
+func FuzzStateSyscallBrk(f *testing.F) {
+	contracts := testContracts(f)
+	addrs := testAddrs
+
+	f.Fuzz(func(t *testing.T, pc, step uint64) {
+		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
+		state := &fast.VMState{
+			PC:              pc,
+			Heap:            0,
+			ExitCode:        0,
+			Exited:          false,
+			Memory:          fast.NewMemory(),
+			LoadReservation: 0,
+			Registers:       [32]uint64{17: fast.SysBrk},
+			Step:            step,
+		}
+		state.Memory.SetUnaligned(pc, syscallInsn)
+		preStateRoot := state.Memory.MerkleRoot()
+		expectedRegisters := state.Registers
+		expectedRegisters[10] = 1 << 30
+		expectedRegisters[11] = 0
+
+		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
+		stepWitness, err := fastState.Step(true)
+		require.NoError(t, err)
+		require.False(t, stepWitness.HasPreimage())
+
+		require.Equal(t, pc+4, state.PC) // PC must advance
+		require.Equal(t, uint64(0), state.Heap)
+		require.Equal(t, uint64(0), state.LoadReservation)
+		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
+		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
+		require.Equal(t, step+1, state.Step) // Step must advance
+		require.Equal(t, expectedRegisters, state.Registers)
+
+		fastPost := state.EncodeWitness()
+		runEVM(t, contracts, addrs, stepWitness, fastPost)
+		runSlow(t, stepWitness, fastPost, nil)
+	})
+}
+
+func FuzzStateSyscallMmap(f *testing.F) {
+	contracts := testContracts(f)
+	addrs := testAddrs
+
+	f.Fuzz(func(t *testing.T, isZeroAddr bool, addr uint64, length uint64, heap uint64, pc uint64, step uint64) {
+		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
+		if isZeroAddr {
+			addr = 0
+		}
+		state := &fast.VMState{
+			PC:              pc,
+			Heap:            heap,
+			ExitCode:        0,
+			Exited:          false,
+			Memory:          fast.NewMemory(),
+			LoadReservation: 0,
+			Registers:       [32]uint64{17: fast.SysMmap, 10: addr, 11: length},
+			Step:            step,
+		}
+		state.Memory.SetUnaligned(pc, syscallInsn)
+		preStateRoot := state.Memory.MerkleRoot()
+		expectedRegisters := state.Registers
+		expectedRegisters[11] = 0
+
+		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
+		stepWitness, err := fastState.Step(true)
+		require.NoError(t, err)
+		require.False(t, stepWitness.HasPreimage())
+
+		require.Equal(t, pc+4, state.PC) // PC must advance
+		require.Equal(t, uint64(0), state.LoadReservation)
+		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
+		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
+		require.Equal(t, step+1, state.Step) // Step must advance
+
+		newHeap := heap
+		if addr == 0 {
+			expectedRegisters[10] = heap
+			align := length & fast.PageAddrMask
+			if align != 0 {
+				length = length + fast.PageSize - align
+			}
+			newHeap = heap + length
+		}
+		require.Equal(t, expectedRegisters, state.Registers)
+		require.Equal(t, newHeap, state.Heap)
+
+		fastPost := state.EncodeWitness()
+		runEVM(t, contracts, addrs, stepWitness, fastPost)
+		runSlow(t, stepWitness, fastPost, nil)
+	})
+}
+
+func FuzzStateSyscallFcntl(f *testing.F) {
+	contracts := testContracts(f)
+	addrs := testAddrs
+
+	testFcntl := func(t *testing.T, fd, cmd, pc, step, out, errCode uint64) {
+		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
+		state := &fast.VMState{
+			PC:              pc,
+			Heap:            0,
+			ExitCode:        0,
+			Exited:          false,
+			Memory:          fast.NewMemory(),
+			LoadReservation: 0,
+			Registers:       [32]uint64{17: fast.SysFcntl, 10: fd, 11: cmd},
+			Step:            step,
+		}
+		state.Memory.SetUnaligned(pc, syscallInsn)
+		preStateRoot := state.Memory.MerkleRoot()
+		expectedRegisters := state.Registers
+		expectedRegisters[10] = out
+		expectedRegisters[11] = errCode
+
+		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
+		stepWitness, err := fastState.Step(true)
+		require.NoError(t, err)
+		require.False(t, stepWitness.HasPreimage())
+
+		require.Equal(t, pc+4, state.PC) // PC must advance
+		require.Equal(t, uint64(0), state.Heap)
+		require.Equal(t, uint64(0), state.LoadReservation)
+		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
+		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
+		require.Equal(t, step+1, state.Step) // Step must advance
+		require.Equal(t, expectedRegisters, state.Registers)
+
+		fastPost := state.EncodeWitness()
+		runEVM(t, contracts, addrs, stepWitness, fastPost)
+		runSlow(t, stepWitness, fastPost, nil)
+	}
+
+	f.Fuzz(func(t *testing.T, fd uint64, cmd uint64, pc uint64, step uint64) {
+		// Test F_GETFL for O_RDONLY fds
+		for _, fd := range []uint64{0, 3, 5} {
+			testFcntl(t, fd, 3, pc, step, 0, 0)
+		}
+		// Test F_GETFL for O_WRONLY fds
+		for _, fd := range []uint64{1, 2, 4, 6} {
+			testFcntl(t, fd, 3, pc, step, 1, 0)
+		}
+		// Test F_GETFL for unsupported fds
+		// Add 7 to fd to ensure fd > 6
+		testFcntl(t, fd+7, 3, pc, step, 0xFFFF_FFFF_FFFF_FFFF, 0x4d)
+
+		// Test other commands
+		if cmd == 3 {
+			// Set arbitrary commands if cmd is F_GETFL
+			cmd = 4
+		}
+		testFcntl(t, fd, cmd, pc, step, 0xFFFF_FFFF_FFFF_FFFF, 0x16)
+	})
+}
+
+func FuzzStateSyscallOpenat(f *testing.F) {
+	contracts := testContracts(f)
+	addrs := testAddrs
+
+	f.Fuzz(func(t *testing.T, pc, step uint64) {
+		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
+		state := &fast.VMState{
+			PC:              pc,
+			Heap:            0,
+			ExitCode:        0,
+			Exited:          false,
+			Memory:          fast.NewMemory(),
+			LoadReservation: 0,
+			Registers:       [32]uint64{17: fast.SysOpenat},
+			Step:            step,
+		}
+		state.Memory.SetUnaligned(pc, syscallInsn)
+		preStateRoot := state.Memory.MerkleRoot()
+		expectedRegisters := state.Registers
+		expectedRegisters[10] = 0xFFFF_FFFF_FFFF_FFFF
+		expectedRegisters[11] = 0xd
+
+		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
+		stepWitness, err := fastState.Step(true)
+		require.NoError(t, err)
+		require.False(t, stepWitness.HasPreimage())
+
+		require.Equal(t, pc+4, state.PC) // PC must advance
+		require.Equal(t, uint64(0), state.Heap)
+		require.Equal(t, uint64(0), state.LoadReservation)
+		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
+		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
+		require.Equal(t, step+1, state.Step) // Step must advance
+		require.Equal(t, expectedRegisters, state.Registers)
+
+		fastPost := state.EncodeWitness()
+		runEVM(t, contracts, addrs, stepWitness, fastPost)
+		runSlow(t, stepWitness, fastPost, nil)
+	})
+}
+
+func FuzzStateSyscallClockGettime(f *testing.F) {
+	contracts := testContracts(f)
+	addrs := testAddrs
+
+	f.Fuzz(func(t *testing.T, addr, pc, step uint64) {
+		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
+		addr = addr &^ 31
+		state := &fast.VMState{
+			PC:              pc,
+			Heap:            0,
+			ExitCode:        0,
+			Exited:          false,
+			Memory:          fast.NewMemory(),
+			LoadReservation: 0,
+			Registers:       [32]uint64{17: fast.SysClockGettime, 11: addr},
+			Step:            step,
+		}
+		state.Memory.SetUnaligned(pc, syscallInsn)
+		expectedRegisters := state.Registers
+		expectedRegisters[11] = 0
+
+		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
+		stepWitness, err := fastState.Step(true)
+		require.NoError(t, err)
+		require.False(t, stepWitness.HasPreimage())
+
+		postMemory := fast.NewMemory()
+		postMemory.SetUnaligned(pc, syscallInsn)
+		var bytes [8]byte
+		binary.LittleEndian.PutUint64(bytes[:], 1337)
+		postMemory.SetUnaligned(addr, bytes[:])
+		postMemory.SetUnaligned(addr+8, []byte{42, 0, 0, 0, 0, 0, 0, 0})
+
+		require.Equal(t, pc+4, state.PC) // PC must advance
+		require.Equal(t, uint64(0), state.Heap)
+		require.Equal(t, uint64(0), state.LoadReservation)
+		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
+		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, state.Memory.MerkleRoot(), postMemory.MerkleRoot())
+		require.Equal(t, step+1, state.Step) // Step must advance
+		require.Equal(t, expectedRegisters, state.Registers)
+
+		fastPost := state.EncodeWitness()
+		runEVM(t, contracts, addrs, stepWitness, fastPost)
+		runSlow(t, stepWitness, fastPost, nil)
+	})
+}
+
+func FuzzStateSyscallClone(f *testing.F) {
+	contracts := testContracts(f)
+	addrs := testAddrs
+
+	f.Fuzz(func(t *testing.T, pc, step uint64) {
+		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
+		state := &fast.VMState{
+			PC:              pc,
+			Heap:            0,
+			ExitCode:        0,
+			Exited:          false,
+			Memory:          fast.NewMemory(),
+			LoadReservation: 0,
+			Registers:       [32]uint64{17: fast.SysClone},
+			Step:            step,
+		}
+		state.Memory.SetUnaligned(pc, syscallInsn)
+		preStateRoot := state.Memory.MerkleRoot()
+		expectedRegisters := state.Registers
+		expectedRegisters[10] = 1
+		expectedRegisters[11] = 0
+
+		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
+		stepWitness, err := fastState.Step(true)
+		require.NoError(t, err)
+		require.False(t, stepWitness.HasPreimage())
+
+		require.Equal(t, pc+4, state.PC) // PC must advance
+		require.Equal(t, uint64(0), state.Heap)
+		require.Equal(t, uint64(0), state.LoadReservation)
+		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
+		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
+		require.Equal(t, step+1, state.Step) // Step must advance
+		require.Equal(t, expectedRegisters, state.Registers)
+
+		fastPost := state.EncodeWitness()
+		runEVM(t, contracts, addrs, stepWitness, fastPost)
+		runSlow(t, stepWitness, fastPost, nil)
+	})
+}
+
+func FuzzStateSyscallGetrlimit(f *testing.F) {
+	contracts := testContracts(f)
+	addrs := testAddrs
+
+	testGetrlimit := func(t *testing.T, addr, pc, step uint64) {
+		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
+		addr = addr &^ 31
+		state := &fast.VMState{
+			PC:              pc,
+			Heap:            0,
+			ExitCode:        0,
+			Exited:          false,
+			Memory:          fast.NewMemory(),
+			LoadReservation: 0,
+			Registers:       [32]uint64{17: fast.SysGetrlimit, 10: 7, 11: addr},
+			Step:            step,
+		}
+		state.Memory.SetUnaligned(pc, syscallInsn)
+		expectedRegisters := state.Registers
+		//expectedRegisters[10] = 0
+		//expectedRegisters[11] = 0
+
+		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
+		stepWitness, err := fastState.Step(true)
+		require.NoError(t, err)
+		require.False(t, stepWitness.HasPreimage())
+
+		postMemory := fast.NewMemory()
+		postMemory.SetUnaligned(pc, syscallInsn)
+		var bytes [8]byte
+		binary.LittleEndian.PutUint64(bytes[:], 1024)
+		postMemory.SetUnaligned(addr, bytes[:])
+		postMemory.SetUnaligned(addr+8, bytes[:])
+
+		require.Equal(t, pc+4, state.PC) // PC must advance
+		require.Equal(t, uint64(0), state.Heap)
+		require.Equal(t, uint64(0), state.LoadReservation)
+		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
+		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, state.Memory.MerkleRoot(), postMemory.MerkleRoot())
+		require.Equal(t, step+1, state.Step) // Step must advance
+		require.Equal(t, expectedRegisters, state.Registers)
+
+		fastPost := state.EncodeWitness()
+		runEVM(t, contracts, addrs, stepWitness, fastPost)
+		runSlow(t, stepWitness, fastPost, nil)
+	}
+
+	testGetrlimitErr := func(t *testing.T, res, addr, pc, step uint64) {
+		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
+		addr = addr &^ 31
+		state := &fast.VMState{
+			PC:              pc,
+			Heap:            0,
+			ExitCode:        0,
+			Exited:          false,
+			Memory:          fast.NewMemory(),
+			LoadReservation: 0,
+			Registers:       [32]uint64{17: fast.SysGetrlimit, 10: res, 11: addr},
+			Step:            0,
+		}
+		state.Memory.SetUnaligned(pc, syscallInsn)
+
+		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
+		_, err := fastState.Step(true)
+		require.Contains(t, err.Error(), "f0012")
+	}
+
+	f.Fuzz(func(t *testing.T, res, addr, pc, step uint64) {
+		// Test RLIMIT_NOFILE
+		testGetrlimit(t, addr, pc, step)
+
+		// Test other resources
+		if res == 7 {
+			// Set arbitrary resource if res is RLIMIT_NOFILE
+			res = 8
+		}
+		testGetrlimitErr(t, res, addr, pc, step)
+	})
+}
+
 func FuzzStateSyscallNoop(f *testing.F) {
 	contracts := testContracts(f)
 	addrs := testAddrs
@@ -187,6 +560,60 @@ func FuzzStateSyscallNoop(f *testing.F) {
 		for _, syscall := range syscalls {
 			testNoop(t, syscall, arg, pc, step)
 		}
+	})
+}
+
+func FuzzStateSyscallRead(f *testing.F) {
+	contracts := testContracts(f)
+	addrs := testAddrs
+
+	testRead := func(t *testing.T, fd, addr, count, pc, step, ret, errCode uint64) {
+		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
+		state := &fast.VMState{
+			PC:              pc,
+			Heap:            0,
+			ExitCode:        0,
+			Exited:          false,
+			Memory:          fast.NewMemory(),
+			LoadReservation: 0,
+			Registers:       [32]uint64{17: fast.SysRead, 10: fd, 11: addr, 12: count},
+			Step:            step,
+		}
+		state.Memory.SetUnaligned(pc, syscallInsn)
+		preStateRoot := state.Memory.MerkleRoot()
+		expectedRegisters := state.Registers
+		expectedRegisters[10] = ret
+		expectedRegisters[11] = errCode
+
+		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
+		stepWitness, err := fastState.Step(true)
+		require.NoError(t, err)
+		require.False(t, stepWitness.HasPreimage())
+
+		require.Equal(t, pc+4, state.PC) // PC must advance
+		require.Equal(t, uint64(0), state.Heap)
+		require.Equal(t, uint64(0), state.LoadReservation)
+		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
+		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
+		require.Equal(t, step+1, state.Step) // Step must advance
+		require.Equal(t, expectedRegisters, state.Registers)
+
+		fastPost := state.EncodeWitness()
+		runEVM(t, contracts, addrs, stepWitness, fastPost)
+		runSlow(t, stepWitness, fastPost, nil)
+	}
+
+	f.Fuzz(func(t *testing.T, fd, addr, count, pc, step uint64) {
+		// Test stdin
+		testRead(t, fast.FdStdin, addr, count, pc, step, 0, 0)
+
+		// Test EBADF err
+		if fd == fast.FdStdin || fd == fast.FdHintRead || fd == fast.FdPreimageRead {
+			// Ensure unsupported fd
+			fd += 1
+		}
+		testRead(t, fd, addr, count, pc, step, 0xFFFF_FFFF_FFFF_FFFF, 0x4d)
 	})
 }
 
@@ -306,6 +733,63 @@ func FuzzStatePreimageRead(f *testing.F) {
 		fastPost := state.EncodeWitness()
 		runEVM(t, contracts, addrs, stepWitness, fastPost)
 		runSlow(t, stepWitness, fastPost, oracle)
+	})
+}
+
+func FuzzStateSyscallWrite(f *testing.F) {
+	contracts := testContracts(f)
+	addrs := testAddrs
+
+	testWrite := func(t *testing.T, fd, addr, count, pc, step, ret, errCode uint64) {
+		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
+		state := &fast.VMState{
+			PC:              pc,
+			Heap:            0,
+			ExitCode:        0,
+			Exited:          false,
+			Memory:          fast.NewMemory(),
+			LoadReservation: 0,
+			Registers:       [32]uint64{17: fast.SysWrite, 10: fd, 11: addr, 12: count},
+			Step:            step,
+		}
+		state.Memory.SetUnaligned(pc, syscallInsn)
+		preStateRoot := state.Memory.MerkleRoot()
+		expectedRegisters := state.Registers
+		expectedRegisters[10] = ret
+		expectedRegisters[11] = errCode
+
+		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
+		stepWitness, err := fastState.Step(true)
+		require.NoError(t, err)
+		require.False(t, stepWitness.HasPreimage())
+
+		require.Equal(t, pc+4, state.PC) // PC must advance
+		require.Equal(t, uint64(0), state.Heap)
+		require.Equal(t, uint64(0), state.LoadReservation)
+		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
+		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
+		require.Equal(t, step+1, state.Step) // Step must advance
+		require.Equal(t, expectedRegisters, state.Registers)
+
+		fastPost := state.EncodeWitness()
+		runEVM(t, contracts, addrs, stepWitness, fastPost)
+		runSlow(t, stepWitness, fastPost, nil)
+	}
+
+	f.Fuzz(func(t *testing.T, fd, addr, count, pc, step uint64) {
+		// Test stdout
+		testWrite(t, fast.FdStdout, addr, count, pc, step, count, 0)
+
+		// Test stderr
+		testWrite(t, fast.FdStderr, addr, count, pc, step, count, 0)
+
+		// Test EBADF err
+		if fd == fast.FdStdout || fd == fast.FdStderr || fd == fast.FdHintWrite || fd == fast.FdPreimageWrite {
+			// Ensure unsupported fd
+			fd += 6
+		}
+		testWrite(t, fd, addr, count, pc, step, 0xFFFF_FFFF_FFFF_FFFF, 0x4d)
 	})
 }
 

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -435,8 +435,8 @@ func FuzzStateSyscallGetrlimit(f *testing.F) {
 		}
 		state.Memory.SetUnaligned(pc, syscallInsn)
 		expectedRegisters := state.Registers
-		//expectedRegisters[10] = 0
-		//expectedRegisters[11] = 0
+		expectedRegisters[10] = 0
+		expectedRegisters[11] = 0
 
 		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
 		stepWitness, err := fastState.Step(true)

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -156,7 +156,7 @@ func FuzzStateSyscallBrk(f *testing.F) {
 		require.Equal(t, uint64(0), state.Heap)
 		require.Equal(t, uint64(0), state.LoadReservation)
 		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
-		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, false, state.Exited)      // Must not be exited
 		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
 		require.Equal(t, step+1, state.Step) // Step must advance
 		require.Equal(t, expectedRegisters, state.Registers)
@@ -199,7 +199,7 @@ func FuzzStateSyscallMmap(f *testing.F) {
 		require.Equal(t, pc+4, state.PC) // PC must advance
 		require.Equal(t, uint64(0), state.LoadReservation)
 		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
-		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, false, state.Exited)      // Must not be exited
 		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
 		require.Equal(t, step+1, state.Step) // Step must advance
 
@@ -252,7 +252,7 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 		require.Equal(t, uint64(0), state.Heap)
 		require.Equal(t, uint64(0), state.LoadReservation)
 		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
-		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, false, state.Exited)      // Must not be exited
 		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
 		require.Equal(t, step+1, state.Step) // Step must advance
 		require.Equal(t, expectedRegisters, state.Registers)
@@ -315,7 +315,7 @@ func FuzzStateSyscallOpenat(f *testing.F) {
 		require.Equal(t, uint64(0), state.Heap)
 		require.Equal(t, uint64(0), state.LoadReservation)
 		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
-		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, false, state.Exited)      // Must not be exited
 		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
 		require.Equal(t, step+1, state.Step) // Step must advance
 		require.Equal(t, expectedRegisters, state.Registers)
@@ -363,7 +363,7 @@ func FuzzStateSyscallClockGettime(f *testing.F) {
 		require.Equal(t, uint64(0), state.Heap)
 		require.Equal(t, uint64(0), state.LoadReservation)
 		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
-		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, false, state.Exited)      // Must not be exited
 		require.Equal(t, state.Memory.MerkleRoot(), postMemory.MerkleRoot())
 		require.Equal(t, step+1, state.Step) // Step must advance
 		require.Equal(t, expectedRegisters, state.Registers)
@@ -405,7 +405,7 @@ func FuzzStateSyscallClone(f *testing.F) {
 		require.Equal(t, uint64(0), state.Heap)
 		require.Equal(t, uint64(0), state.LoadReservation)
 		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
-		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, false, state.Exited)      // Must not be exited
 		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
 		require.Equal(t, step+1, state.Step) // Step must advance
 		require.Equal(t, expectedRegisters, state.Registers)
@@ -454,7 +454,7 @@ func FuzzStateSyscallGetrlimit(f *testing.F) {
 		require.Equal(t, uint64(0), state.Heap)
 		require.Equal(t, uint64(0), state.LoadReservation)
 		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
-		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, false, state.Exited)      // Must not be exited
 		require.Equal(t, state.Memory.MerkleRoot(), postMemory.MerkleRoot())
 		require.Equal(t, step+1, state.Step) // Step must advance
 		require.Equal(t, expectedRegisters, state.Registers)
@@ -594,7 +594,7 @@ func FuzzStateSyscallRead(f *testing.F) {
 		require.Equal(t, uint64(0), state.Heap)
 		require.Equal(t, uint64(0), state.LoadReservation)
 		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
-		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, false, state.Exited)      // Must not be exited
 		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
 		require.Equal(t, step+1, state.Step) // Step must advance
 		require.Equal(t, expectedRegisters, state.Registers)
@@ -767,7 +767,7 @@ func FuzzStateSyscallWrite(f *testing.F) {
 		require.Equal(t, uint64(0), state.Heap)
 		require.Equal(t, uint64(0), state.LoadReservation)
 		require.Equal(t, uint8(0), state.ExitCode) // ExitCode must be set
-		require.Equal(t, false, state.Exited)      // Must be exited
+		require.Equal(t, false, state.Exited)      // Must not be exited
 		require.Equal(t, preStateRoot, state.Memory.MerkleRoot())
 		require.Equal(t, step+1, state.Step) // Step must advance
 		require.Equal(t, expectedRegisters, state.Registers)

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -996,6 +996,8 @@ contract RISCV {
                         // first 8 bytes: soft limit. 1024 file handles max open
                         // second 8 bytes: hard limit
                         storeMemUnaligned(addr, toU64(16), or(shortToU256(1024), shl(toU256(64), shortToU256(1024))), 1, 2)
+                        setRegister(toU64(10), toU64(0))
+                        setRegister(toU64(11), toU64(0))
                     } default {
                         revertWithCode(0xf0012) // unrecognized resource limit lookup
                     }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Following up on the previous PR(https://github.com/ethereum-optimism/asterisc/pull/21), added fuzz tests for rest of syscalls.
- FuzzStateSyscallBrk
- FuzzStateSyscallMmap
- FuzzStateSyscallFcntl
- FuzzStateSyscallOpenat
- FuzzStateSyscallClockGettime
- FuzzStateSyscallClone
- FuzzStateSyscallGetrlimit
- FuzzStateRead
  - stdin, errors
- FuzzStateWrite
  - stdout, stderr, errors

And fixed getrlimit syscall implementation to return 0 ([ref](https://man7.org/linux/man-pages/man2/getrlimit.2.html#RETURN_VALUE))
