### PR TITLE
Tip/rvgo test revert

### DIFF
--- a/rvgo/fast/instrumented.go
+++ b/rvgo/fast/instrumented.go
@@ -55,9 +55,6 @@ func (m *InstrumentedState) Step(proof bool) (wit *StepWitness, err error) {
 	}
 
 	err = m.riscvStep()
-	if err != nil {
-		return nil, err
-	}
 
 	if proof {
 		wit.MemProof = make([]byte, 0, len(m.memProofs)*memProofSize)
@@ -70,6 +67,7 @@ func (m *InstrumentedState) Step(proof bool) (wit *StepWitness, err error) {
 			wit.PreimageValue = m.lastPreimage
 		}
 	}
+
 	return
 }
 

--- a/rvgo/riscv/constants.go
+++ b/rvgo/riscv/constants.go
@@ -38,4 +38,21 @@ const (
 	FdHintWrite     = 4
 	FdPreimageRead  = 5
 	FdPreimageWrite = 6
+
+	ErrUnrecognizedResource           = uint64(0xf0012)
+	ErrUnknownAtomicOperation         = uint64(0xf001a70)
+	ErrUnknownOpCode                  = uint64(0xf001c0de)
+	ErrInvalidSyscall                 = uint64(0xf001ca11)
+	ErrInvalidRegister                = uint64(0xbad4e9)
+	ErrNotAlignedAddr                 = uint64(0xbad10ad0)
+	ErrLoadExceeds8Bytes              = uint64(0xbad512e0)
+	ErrStoreExceeds8Bytes             = uint64(0xbad512e8)
+	ErrStoreExceeds32Bytes            = uint64(0xbad512e1)
+	ErrUnexpectedRProofLoad           = uint64(0xbad22220)
+	ErrUnexpectedRProofStoreUnaligned = uint64(0xbad22221)
+	ErrUnexpectedRProofStore          = uint64(0xbad2222f)
+	ErrUnknownCSRMode                 = uint64(0xbadc0de0)
+	ErrBadAMOSize                     = uint64(0xbada70)
+	ErrFailToReadPreimage             = uint64(0xbadf00d0)
+	ErrBadMemoryProof                 = uint64(0xbadf00d1)
 )

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -217,7 +217,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 
 	getRegister := func(reg U64) U64 {
 		if gt64(reg, toU64(31)) != (U64{}) {
-			revertWithCode(0xbad4e9, fmt.Errorf("cannot load invalid register: %d", reg.val()))
+			revertWithCode(riscv.ErrInvalidRegister, fmt.Errorf("cannot load invalid register: %d", reg.val()))
 		}
 		//fmt.Printf("load reg %2d: %016x\n", reg, state.Registers[reg])
 		offset := add64(toU64(stateOffsetRegisters), mul64(reg, toU64(8)))
@@ -230,7 +230,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 			return
 		}
 		if gt64(reg, toU64(31)) != (U64{}) {
-			revertWithCode(0xbad4e9, fmt.Errorf("unknown register %d, cannot write %x", reg.val(), v.val()))
+			revertWithCode(riscv.ErrInvalidRegister, fmt.Errorf("unknown register %d, cannot write %x", reg.val(), v.val()))
 		}
 		offset := add64(toU64(stateOffsetRegisters), mul64(reg, toU64(8)))
 		writeState(offset.val(), 8, encodeU64BE(v))
@@ -282,7 +282,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 
 	getMemoryB32 := func(addr U64, proofIndex uint8) (out [32]byte) {
 		if and64(addr, toU64(31)) != (U64{}) { // quick addr alignment check
-			revertWithCode(0xbad10ad0, fmt.Errorf("addr %d not aligned with 32 bytes", addr))
+			revertWithCode(riscv.ErrNotAlignedAddr, fmt.Errorf("addr %d not aligned with 32 bytes", addr))
 		}
 		offset := proofOffset(proofIndex)
 		leaf := calldataload(offset)
@@ -302,7 +302,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		}
 		memRoot := getMemRoot()
 		if iszero(eq(b32asBEWord(node), b32asBEWord(memRoot))) { // verify the root matches
-			revertWithCode(0xbadf00d1, fmt.Errorf("bad memory proof, got mem root: %x, expected %x", node, memRoot))
+			revertWithCode(riscv.ErrBadMemoryProof, fmt.Errorf("bad memory proof, got mem root: %x, expected %x", node, memRoot))
 		}
 		out = leaf
 		return
@@ -312,7 +312,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 	// it assumes the same memory proof has been verified with getMemoryB32
 	setMemoryB32 := func(addr U64, v [32]byte, proofIndex uint8) {
 		if and64(addr, toU64(31)) != (U64{}) {
-			revertWithCode(0xbad10ad0, fmt.Errorf("addr %d not aligned with 32 bytes", addr))
+			revertWithCode(riscv.ErrNotAlignedAddr, fmt.Errorf("addr %d not aligned with 32 bytes", addr))
 		}
 		offset := proofOffset(proofIndex)
 		leaf := v
@@ -336,7 +336,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 	// load unaligned, optionally signed, little-endian, integer of 1 ... 8 bytes from memory
 	loadMem := func(addr U64, size U64, signed bool, proofIndexL uint8, proofIndexR uint8) (out U64) {
 		if size.val() > 8 {
-			revertWithCode(0xbad512e0, fmt.Errorf("cannot load more than 8 bytes: %d", size))
+			revertWithCode(riscv.ErrLoadExceeds8Bytes, fmt.Errorf("cannot load more than 8 bytes: %d", size))
 		}
 		// load/verify left part
 		leftAddr := and64(addr, not64(toU64(31)))
@@ -350,7 +350,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		if iszero64(eq64(leftAddr, rightAddr)) {
 			// if unaligned, use second proof for the right part
 			if proofIndexR == 0xff {
-				revertWithCode(0xbad22220, fmt.Errorf("unexpected need for right-side proof %d in loadMem", proofIndexR))
+				revertWithCode(riscv.ErrUnexpectedRProofLoad, fmt.Errorf("unexpected need for right-side proof %d in loadMem", proofIndexR))
 			}
 			// load/verify right part
 			right = b32asBEWord(getMemoryB32(rightAddr, proofIndexR))
@@ -421,7 +421,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 
 	storeMemUnaligned := func(addr U64, size U64, value U256, proofIndexL uint8, proofIndexR uint8) {
 		if size.val() > 32 {
-			revertWithCode(0xbad512e1, fmt.Errorf("cannot store more than 32 bytes: %d", size))
+			revertWithCode(riscv.ErrStoreExceeds32Bytes, fmt.Errorf("cannot store more than 32 bytes: %d", size))
 		}
 
 		leftAddr := and64(addr, not64(toU64(31)))
@@ -441,7 +441,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 			return
 		}
 		if proofIndexR == 0xff {
-			revertWithCode(0xbad22221, fmt.Errorf("unexpected need for right-side proof %d in storeMemUnaligned", proofIndexR))
+			revertWithCode(riscv.ErrUnexpectedRProofStoreUnaligned, fmt.Errorf("unexpected need for right-side proof %d in storeMemUnaligned", proofIndexR))
 		}
 		// load the right base (with updated mem root)
 		right := b32asBEWord(getMemoryB32(rightAddr, proofIndexR))
@@ -475,7 +475,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		case 3: // ?11 = CSRRC(I)
 			v = and64(out, not64(v))
 		default:
-			revertWithCode(0xbadc0de0, fmt.Errorf("unkwown CSR mode: %d", mode.val()))
+			revertWithCode(riscv.ErrUnknownCSRMode, fmt.Errorf("unkwown CSR mode: %d", mode.val()))
 		}
 		writeCSR(num, v)
 		return
@@ -521,7 +521,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 			datlen = toU64(l)
 			return
 		}
-		revertWithCode(0xbadf00d0, err)
+		revertWithCode(riscv.ErrFailToReadPreimage, err)
 		return
 	}
 
@@ -734,7 +734,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 				setRegister(toU64(10), toU64(0))
 				setRegister(toU64(11), toU64(0))
 			default:
-				revertWithCode(0xf0012, &UnrecognizedResourceErr{Resource: res})
+				revertWithCode(riscv.ErrUnrecognizedResource, &UnrecognizedResourceErr{Resource: res})
 			}
 		case riscv.SysMadvise: // madvise - ignored
 			setRegister(toU64(10), toU64(0))
@@ -764,13 +764,13 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 			setRegister(toU64(10), toU64(0))
 			setRegister(toU64(11), toU64(0))
 		case riscv.SysPrlimit64: // prlimit64 -- unsupported, we have getrlimit, is prlimit64 even called?
-			revertWithCode(0xf001ca11, &UnsupportedSyscallErr{SyscallNum: a7})
+			revertWithCode(riscv.ErrInvalidSyscall, &UnsupportedSyscallErr{SyscallNum: a7})
 		case riscv.SysFutex: // futex - not supported, for now
-			revertWithCode(0xf001ca11, &UnsupportedSyscallErr{SyscallNum: a7})
+			revertWithCode(riscv.ErrInvalidSyscall, &UnsupportedSyscallErr{SyscallNum: a7})
 		case riscv.SysNanosleep: // nanosleep - not supported, for now
-			revertWithCode(0xf001ca11, &UnsupportedSyscallErr{SyscallNum: a7})
+			revertWithCode(riscv.ErrInvalidSyscall, &UnsupportedSyscallErr{SyscallNum: a7})
 		default:
-			revertWithCode(0xf001ca11, &UnrecognizedSyscallErr{SyscallNum: a7})
+			revertWithCode(riscv.ErrInvalidSyscall, &UnrecognizedSyscallErr{SyscallNum: a7})
 		}
 	}
 
@@ -1085,7 +1085,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		// 0b011 == RV64A D variants
 		size := shl64(funct3, toU64(1))
 		if lt64(size, toU64(4)) != (U64{}) {
-			revertWithCode(0xbada70, fmt.Errorf("bad AMO size: %d", size))
+			revertWithCode(riscv.ErrBadAMOSize, fmt.Errorf("bad AMO size: %d", size))
 		}
 		addr := getRegister(rs1)
 		// TODO check if addr is aligned
@@ -1141,7 +1141,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 					v = value
 				}
 			default:
-				revertWithCode(0xf001a70, fmt.Errorf("unknown atomic operation %d", op))
+				revertWithCode(riscv.ErrUnknownAtomicOperation, fmt.Errorf("unknown atomic operation %d", op))
 			}
 			storeMem(addr, size, v, 1, 3) // after overwriting 1, proof 2 is no longer valid
 			setRegister(rd, rdValue)
@@ -1159,7 +1159,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 	case 0x53: // FADD etc. no-op is enough to pass Go runtime check
 		setPC(add64(pc, toU64(4))) // no-op this.
 	default:
-		revertWithCode(0xf001c0de, fmt.Errorf("unknown instruction opcode: %d", opcode))
+		revertWithCode(riscv.ErrUnknownOpCode, fmt.Errorf("unknown instruction opcode: %d", opcode))
 	}
 	return computeStateHash(), nil
 }

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -82,8 +82,7 @@ func TestStateSyscallUnsupported(t *testing.T) {
 			var fastSyscallErr *fast.UnsupportedSyscallErr
 			require.ErrorAs(t, err, &fastSyscallErr)
 
-			revertCode := uint64(0xf001ca11)
-			runEVM(t, contracts, addrs, stepWitness, nil, errCodeToByte32(revertCode))
+			runEVM(t, contracts, addrs, stepWitness, nil, errCodeToByte32(riscv.ErrInvalidSyscall))
 
 			var slowSyscallErr *slow.UnsupportedSyscallErr
 			runSlow(t, stepWitness, nil, nil, &slowSyscallErr)
@@ -498,8 +497,7 @@ func FuzzStateSyscallGetrlimit(f *testing.F) {
 		var fastSyscallErr *fast.UnrecognizedResourceErr
 		require.ErrorAs(t, err, &fastSyscallErr)
 
-		revertCode := uint64(0xf0012)
-		runEVM(t, contracts, addrs, stepWitness, nil, errCodeToByte32(revertCode))
+		runEVM(t, contracts, addrs, stepWitness, nil, errCodeToByte32(riscv.ErrUnrecognizedResource))
 
 		var slowSyscallErr *slow.UnrecognizedResourceErr
 		runSlow(t, stepWitness, nil, nil, &slowSyscallErr)

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -30,22 +30,32 @@ func staticOracle(t *testing.T, preimageData []byte) *testOracle {
 	}
 }
 
-func runEVM(t *testing.T, contracts *Contracts, addrs *Addresses, stepWitness *fast.StepWitness, fastPost fast.StateWitness) {
+func runEVM(t *testing.T, contracts *Contracts, addrs *Addresses, stepWitness *fast.StepWitness, fastPost fast.StateWitness, revertCode []byte) {
 	env := newEVMEnv(t, contracts, addrs)
-	evmPost, _, _ := stepEVM(t, env, stepWitness, addrs, 0)
+	evmPost, _, _ := stepEVM(t, env, stepWitness, addrs, 0, revertCode)
 	require.Equal(t, hexutil.Bytes(fastPost).String(), hexutil.Bytes(evmPost).String(),
 		"fast VM produced different state than EVM")
 }
 
-func runSlow(t *testing.T, stepWitness *fast.StepWitness, fastPost fast.StateWitness, po slow.PreimageOracle) {
+func runSlow(t *testing.T, stepWitness *fast.StepWitness, fastPost fast.StateWitness, po slow.PreimageOracle, expectedErr interface{}) {
 	slowPostHash, err := slow.Step(stepWitness.EncodeStepInput(fast.LocalContext{}), po)
-	require.NoError(t, err)
-	fastPostHash, err := fastPost.StateHash()
-	require.NoError(t, err)
-	require.Equal(t, fastPostHash, slowPostHash, "fast VM produced different state than slow VM")
+	if expectedErr != nil {
+		require.ErrorAs(t, err, expectedErr)
+	} else {
+		fastPostHash, err := fastPost.StateHash()
+		require.NoError(t, err)
+		require.Equal(t, fastPostHash, slowPostHash, "fast VM produced different state than slow VM")
+	}
+
+}
+
+func errCodeToByte32(errCode uint64) []byte {
+	return binary.BigEndian.AppendUint64(make([]byte, 24), errCode)
 }
 
 func TestStateSyscallUnsupported(t *testing.T) {
+	contracts := testContracts(t)
+	addrs := testAddrs
 	syscalls := []int{
 		riscv.SysPrlimit64,
 		riscv.SysFutex,
@@ -68,11 +78,15 @@ func TestStateSyscallUnsupported(t *testing.T) {
 			state.Memory.SetUnaligned(pc, syscallInsn)
 
 			fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
-			_, err := fastState.Step(true)
-			var syscallErr *fast.UnsupportedSyscallErr
-			require.ErrorAs(t, err, &syscallErr)
+			stepWitness, err := fastState.Step(true)
+			var fastSyscallErr *fast.UnsupportedSyscallErr
+			require.ErrorAs(t, err, &fastSyscallErr)
 
-			// TODO: Test EVM & slow VM
+			revertCode := uint64(0xf001ca11)
+			runEVM(t, contracts, addrs, stepWitness, nil, errCodeToByte32(revertCode))
+
+			var slowSyscallErr *slow.UnsupportedSyscallErr
+			runSlow(t, stepWitness, nil, nil, &slowSyscallErr)
 		})
 	}
 }
@@ -114,8 +128,8 @@ func FuzzStateSyscallExit(f *testing.F) {
 		require.Equal(t, preStateRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	}
 
 	f.Fuzz(func(t *testing.T, exitCode uint8, pc uint64, step uint64) {
@@ -162,8 +176,8 @@ func FuzzStateSyscallBrk(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	})
 }
 
@@ -216,8 +230,8 @@ func FuzzStateSyscallMmap(f *testing.F) {
 		require.Equal(t, newHeap, state.Heap)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	})
 }
 
@@ -258,8 +272,8 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	}
 
 	f.Fuzz(func(t *testing.T, fd uint64, cmd uint64, pc uint64, step uint64) {
@@ -321,8 +335,8 @@ func FuzzStateSyscallOpenat(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	})
 }
 
@@ -369,8 +383,8 @@ func FuzzStateSyscallClockGettime(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	})
 }
 
@@ -411,8 +425,8 @@ func FuzzStateSyscallClone(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	})
 }
 
@@ -460,8 +474,8 @@ func FuzzStateSyscallGetrlimit(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	}
 
 	testGetrlimitErr := func(t *testing.T, res, addr, pc, step uint64) {
@@ -480,9 +494,15 @@ func FuzzStateSyscallGetrlimit(f *testing.F) {
 		state.Memory.SetUnaligned(pc, syscallInsn)
 
 		fastState := fast.NewInstrumentedState(state, nil, os.Stdout, os.Stderr)
-		_, err := fastState.Step(true)
-		require.Contains(t, err.Error(), "f0012")
-		// TODO: Test EVM & slow VM
+		stepWitness, err := fastState.Step(true)
+		var fastSyscallErr *fast.UnrecognizedResourceErr
+		require.ErrorAs(t, err, &fastSyscallErr)
+
+		revertCode := uint64(0xf0012)
+		runEVM(t, contracts, addrs, stepWitness, nil, errCodeToByte32(revertCode))
+
+		var slowSyscallErr *slow.UnrecognizedResourceErr
+		runSlow(t, stepWitness, nil, nil, &slowSyscallErr)
 	}
 
 	f.Fuzz(func(t *testing.T, res, addr, pc, step uint64) {
@@ -553,8 +573,8 @@ func FuzzStateSyscallNoop(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	}
 
 	f.Fuzz(func(t *testing.T, arg uint64, pc uint64, step uint64) {
@@ -601,8 +621,8 @@ func FuzzStateSyscallRead(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	}
 
 	f.Fuzz(func(t *testing.T, fd, addr, count, pc, step uint64) {
@@ -665,8 +685,8 @@ func FuzzStateHintRead(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, oracle)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, oracle, nil)
 	})
 }
 
@@ -732,8 +752,8 @@ func FuzzStatePreimageRead(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, oracle)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, oracle, nil)
 	})
 }
 
@@ -774,8 +794,8 @@ func FuzzStateSyscallWrite(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, nil)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, nil, nil)
 	}
 
 	f.Fuzz(func(t *testing.T, fd, addr, count, pc, step uint64) {
@@ -845,8 +865,8 @@ func FuzzStateHintWrite(f *testing.F) {
 		require.Equal(t, expectedRegisters, state.Registers)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, oracle)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, oracle, nil)
 	})
 }
 
@@ -917,7 +937,7 @@ func FuzzStatePreimageWrite(f *testing.F) {
 		require.Equal(t, expectedKey, state.PreimageKey)
 
 		fastPost := state.EncodeWitness()
-		runEVM(t, contracts, addrs, stepWitness, fastPost)
-		runSlow(t, stepWitness, fastPost, oracle)
+		runEVM(t, contracts, addrs, stepWitness, fastPost, nil)
+		runSlow(t, stepWitness, fastPost, oracle, nil)
 	})
 }

--- a/rvgo/test/vm_go_test.go
+++ b/rvgo/test/vm_go_test.go
@@ -114,7 +114,7 @@ func fullTest(t *testing.T, vmState *fast.VMState, po *testOracle, symbols fast.
 			}
 
 			if runEVM {
-				evmPost, evmPostHash, gasUsed := stepEVM(t, env, wit, addrs, i)
+				evmPost, evmPostHash, gasUsed := stepEVM(t, env, wit, addrs, i, nil)
 				if gasUsed > maxGasUsed {
 					maxGasUsed = gasUsed
 				}

--- a/rvgo/test/vm_test.go
+++ b/rvgo/test/vm_test.go
@@ -121,7 +121,7 @@ func runEVMTestSuite(t *testing.T, path string) {
 		wit, err := instState.Step(true)
 		require.NoError(t, err)
 
-		evmPost, evmPostHash, gasUsed := stepEVM(t, env, wit, addrs, i)
+		evmPost, evmPostHash, gasUsed := stepEVM(t, env, wit, addrs, i, nil)
 		if gasUsed > maxGasUsed {
 			maxGasUsed = gasUsed
 		}


### PR DESCRIPTION
**Description**

Existing syscall fuzz test cases cannot test step revert for slow VM & EVM. This PR enables revert test for those VMs.
And replaced hardcoded error codes with constants