### PR TITLE
Fix fast VM storeMemUnaligned()

### DIFF
--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -218,7 +218,7 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 			inst.trackMemAccess(rightAddr, proofIndexR)
 		}
 		inst.verifyMemChange(rightAddr, proofIndexR)
-		s.Memory.SetUnaligned(addr, bytez[leftSize:size])
+		s.Memory.SetUnaligned(rightAddr, bytez[leftSize:size])
 	}
 
 	storeMem := func(addr U64, size U64, value U64, proofIndexL uint8, proofIndexR uint8, verifyL bool, verifyR bool) {

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -422,7 +422,6 @@ func FuzzStateSyscallGetrlimit(f *testing.F) {
 
 	testGetrlimit := func(t *testing.T, addr, pc, step uint64) {
 		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
-		addr = addr &^ 31
 		state := &fast.VMState{
 			PC:              pc,
 			Heap:            0,


### PR DESCRIPTION
**Description**

Fast VM's storeMemUnaligned() does not set the right part of the unaligned data. However, the bug is not tested via fuzz test case because it uses only aligned addresses.
I fixed the bug to make it behave the same way with [slow VM](https://github.com/ethereum-optimism/asterisc/blob/master/rvgo/slow/vm.go#L430) and [rvsol](https://github.com/ethereum-optimism/asterisc/blob/master/rvsol/src/RISCV.sol#L730).