### PR TITLE
Allow misaligned clock_gettime syscall

### DIFF
--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -508,8 +508,8 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 		case riscv.SysClockGettime: // clock_gettime
 			addr := getRegister(toU64(11)) // addr of timespec struct
 			// write 1337s + 42ns as time
-			storeMemUnaligned(addr, toU64(8), shortToU256(1337), 1, 0xff, true, false)
-			storeMemUnaligned(add64(addr, toU64(8)), toU64(8), toU256(42), 2, 0xff, true, false)
+			value := or(shortToU256(1337), shl(shortToU256(64), toU256(42)))
+			storeMemUnaligned(addr, toU64(16), value, 1, 2, true, true)
 			setRegister(toU64(10), toU64(0))
 			setRegister(toU64(11), toU64(0))
 		case riscv.SysRtSigprocmask: // rt_sigprocmask - ignore any sigset changes

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -683,8 +683,8 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		case riscv.SysClockGettime: // clock_gettime
 			addr := getRegister(toU64(11)) // addr of timespec struct
 			// write 1337s + 42ns as time
-			storeMemUnaligned(addr, toU64(8), shortToU256(1337), 1, 0xff)
-			storeMemUnaligned(add64(addr, toU64(8)), toU64(8), toU256(42), 2, 0xff)
+			value := or(shortToU256(1337), shl(shortToU256(64), toU256(42)))
+			storeMemUnaligned(addr, toU64(16), value, 1, 2)
 			setRegister(toU64(10), toU64(0))
 			setRegister(toU64(11), toU64(0))
 		case riscv.SysRtSigprocmask: // rt_sigprocmask - ignore any sigset changes

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -332,7 +332,6 @@ func FuzzStateSyscallClockGettime(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, addr, pc, step uint64) {
 		pc = pc & 0xFF_FF_FF_FF_FF_FF_FF_FC // align PC
-		addr = addr &^ 31
 		state := &fast.VMState{
 			PC:              pc,
 			Heap:            0,

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1057,8 +1057,8 @@ contract RISCV {
                     // clock_gettime
                     let addr := getRegister(toU64(11)) // addr of timespec struct
                     // write 1337s + 42ns as time
-                    storeMemUnaligned(addr, toU64(8), shortToU256(1337), 1, 0xff)
-                    storeMemUnaligned(add64(addr, toU64(8)), toU64(8), toU256(42), 2, 0xff)
+                    let value := or(shortToU256(1337), shl(shortToU256(64), toU256(42)))
+                    storeMemUnaligned(addr, toU64(16), value, 1, 2)
                     setRegister(toU64(10), toU64(0))
                     setRegister(toU64(11), toU64(0))
                 }


### PR DESCRIPTION
**Description**

The original implementation of the `clock_gettime` syscall does not allow a misaligned address for the destination. However, at the same time, it calls `storeMemUnaligned()` twice, which makes the proof size longer. 

I tried to find the spec of Linux syscall to know if `clock_gettime` should allow a misaligned destination, but it seems there's no spec about that, and it depends on the kernel implementation.
I read some Linux kernel source code, and it seems RISC-V allows a misaligned destination. (see following files: [`kernel/time/posix-timers.c`](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/time/posix-timers.c?h=v6.8.2#n1132), [`kernel/time/time.c`](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/time/time.c?h=v6.8.2#n902), and [`arch/riscv/lib/uaccess.S`](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch/riscv/lib/uaccess.S?h=v6.8.2#n15))

So I fixed it to allow misaligned addresses for its destination, using one `storeMemUnaligned()`.
