### PR TITLE
rvgo: Embed witness and stateHash to state

### DIFF
--- a/rvgo/cmd/load_elf.go
+++ b/rvgo/cmd/load_elf.go
@@ -32,6 +32,10 @@ func LoadELF(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to compute program metadata: %w", err)
 	}
+	// Must set witness and stateHash after initial state is prepared
+	if err := state.SetWitnessAndStateHash(); err != nil {
+		return fmt.Errorf("failed to set witness and stateHash: %w", err)
+	}
 	if err := jsonutil.WriteJSON[*Metadata](ctx.Path(cannon.LoadELFMetaFlag.Name), meta, OutFilePerm); err != nil {
 		return fmt.Errorf("failed to output metadata: %w", err)
 	}

--- a/rvgo/cmd/run.go
+++ b/rvgo/cmd/run.go
@@ -223,6 +223,10 @@ func Run(ctx *cli.Context) error {
 		}
 	}
 
+	if err := state.SetWitnessAndStateHash(); err != nil {
+		return fmt.Errorf("failed to set witness and stateHash: %w", err)
+	}
+
 	if err := jsonutil.WriteJSON(ctx.Path(cannon.RunOutputFlag.Name), state, OutFilePerm); err != nil {
 		return fmt.Errorf("failed to write state output: %w", err)
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

op-challenger must import FPVM codes to calculate witness and statehash itself. By saving witness and statehash to the state struct, we remove this burden.

golint ci fails. Fixed at https://github.com/ethereum-optimism/asterisc/pull/38 and will rebase.


