### PR TITLE
rvgo: Fix lint

### DIFF
--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -87,7 +87,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 			if err, ok := errInterface.(error); ok {
 				outErr = fmt.Errorf("revert: %w", err)
 			} else {
-				outErr = fmt.Errorf("revert: %v", err)
+				outErr = fmt.Errorf("revert: %v", err) // nolint:errorlint
 			}
 
 		}

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -42,7 +42,7 @@ func runSlow(t *testing.T, stepWitness *fast.StepWitness, fastPost fast.StateWit
 	if expectedErr != nil {
 		require.ErrorAs(t, err, expectedErr)
 	} else {
-                require.NoError(t, err)
+		require.NoError(t, err)
 		fastPostHash, err := fastPost.StateHash()
 		require.NoError(t, err)
 		require.Equal(t, fastPostHash, slowPostHash, "fast VM produced different state than slow VM")


### PR DESCRIPTION
https://github.com/ethereum-optimism/asterisc/pull/31 did not have linter enabled.