### PR TITLE
rvsol: Dump post state after asterisc deployment on devnet

### DIFF
--- a/rvsol/scripts/Artifacts.s.sol
+++ b/rvsol/scripts/Artifacts.s.sol
@@ -57,7 +57,6 @@ abstract contract Artifacts {
 
         // Load L1 allocs from a genesis file
         l1Allocfile = Config.chainL1AllocPath();
-        vm.loadAllocs(l1Allocfile);
 
         // Prepare absolute asterisc prestate
         asteriscPrestatefile = Config.asteriscPrestatePath();

--- a/rvsol/scripts/Artifacts.s.sol
+++ b/rvsol/scripts/Artifacts.s.sol
@@ -29,6 +29,8 @@ abstract contract Artifacts {
     mapping(string => Deployment) internal _namedDeployments;
     /// @notice The path to the deployment artifact that is being written to.
     string internal deploymentOutfile;
+    /// @notice The path to the asterisc absolute prestate.
+    string internal asteriscPrestatefile;
 
     /// @notice Accepts a filepath and then ensures that the directory
     ///         exists for the file to live in.
@@ -49,6 +51,9 @@ abstract contract Artifacts {
         deploymentOutfile = Config.deploymentOutfile();
         console.log("Writing artifact to %s", deploymentOutfile);
         ensurePath(deploymentOutfile);
+
+        // Prepare absolute asterisc prestate
+        asteriscPrestatefile = Config.asteriscPrestatePath();
 
         // Load addresses from a JSON file if the TARGET_L2_DEPLOYMENT_FILE environment variable
         // is set. Great for loading addresses from `superchain-registry`.

--- a/rvsol/scripts/Artifacts.s.sol
+++ b/rvsol/scripts/Artifacts.s.sol
@@ -29,6 +29,9 @@ abstract contract Artifacts {
     mapping(string => Deployment) internal _namedDeployments;
     /// @notice The path to the deployment artifact that is being written to.
     string internal deploymentOutfile;
+    /// @notice The path to the l1 Alloc that is being loaded for asterisc deployment.
+    //          Required because we assume all other components are already at chaindata.
+    string internal l1Allocfile;
     /// @notice The path to the asterisc absolute prestate.
     string internal asteriscPrestatefile;
 
@@ -51,6 +54,10 @@ abstract contract Artifacts {
         deploymentOutfile = Config.deploymentOutfile();
         console.log("Writing artifact to %s", deploymentOutfile);
         ensurePath(deploymentOutfile);
+
+        // Load L1 allocs from a genesis file
+        l1Allocfile = Config.chainL1AllocPath();
+        vm.loadAllocs(l1Allocfile);
 
         // Prepare absolute asterisc prestate
         asteriscPrestatefile = Config.asteriscPrestatePath();

--- a/rvsol/scripts/Config.sol
+++ b/rvsol/scripts/Config.sol
@@ -31,6 +31,10 @@ library Config {
         _env = vm.envOr("TARGET_L2_DEPLOYMENT_FILE", string("./.deploy"));
     }
 
+    function asteriscPrestatePath() internal view returns (string memory _env) {
+        _env = vm.envOr("ASTERISC_PRESTATE", string.concat(vm.projectRoot(), "/../rvgo/bin/prestate-proof.json"));
+    }
+
     /// @notice Returns the chainid from the EVM context or the value of the CHAIN_ID env var as
     ///         an override.
     function chainID() internal view returns (uint256 _env) {

--- a/rvsol/scripts/Config.sol
+++ b/rvsol/scripts/Config.sol
@@ -31,6 +31,10 @@ library Config {
         _env = vm.envOr("TARGET_L2_DEPLOYMENT_FILE", string("./.deploy"));
     }
 
+    function chainL1AllocPath() internal view returns (string memory _env) {
+        _env = vm.envOr("TARGET_L1_ALLOC", string("./allocs-L1.json"));
+    }
+
     function asteriscPrestatePath() internal view returns (string memory _env) {
         _env = vm.envOr("ASTERISC_PRESTATE", string.concat(vm.projectRoot(), "/../rvgo/bin/prestate-proof.json"));
     }

--- a/rvsol/scripts/Deploy.s.sol
+++ b/rvsol/scripts/Deploy.s.sol
@@ -42,6 +42,10 @@ contract Deploy is Deployer {
     function run() public {
         deployRiscv();
         setAsteriscFaultGameImplementation(false);
+        string memory path = vm.envOr(
+            "STATE_DUMP_PATH", string.concat(vm.projectRoot(), "/", name(), "-", vm.toString(block.chainid), ".json")
+        );
+        vm.dumpState(path);
     }
 
     /// @notice Deploy RISCV

--- a/rvsol/scripts/Deploy.s.sol
+++ b/rvsol/scripts/Deploy.s.sol
@@ -58,7 +58,7 @@ contract Deploy is Deployer {
     function loadRiscvAbsolutePrestate() internal returns (Claim riscvAbsolutePrestate_) {
         if (block.chainid == Chains.LocalDevnet || block.chainid == Chains.GethDevnet) {
             // Fetch the absolute prestate dump
-            string memory filePath = string.concat(vm.projectRoot(), "/../rvgo/bin/prestate-proof.json");
+            string memory filePath = asteriscPrestatefile;
             string[] memory commands = new string[](3);
             commands[0] = "bash";
             commands[1] = "-c";

--- a/rvsol/scripts/Deploy.s.sol
+++ b/rvsol/scripts/Deploy.s.sol
@@ -42,6 +42,11 @@ contract Deploy is Deployer {
     function run() public {
         deployRiscv();
         setAsteriscFaultGameImplementation(false);
+    }
+
+    function runForDevnetAlloc() public {
+        vm.loadAllocs(l1Allocfile);
+        run();
         string memory path = vm.envOr(
             "STATE_DUMP_PATH", string.concat(vm.projectRoot(), "/", name(), "-", vm.toString(block.chainid), ".json")
         );

--- a/rvsol/scripts/create_poststate_after_deployment.sh
+++ b/rvsol/scripts/create_poststate_after_deployment.sh
@@ -1,0 +1,23 @@
+set -eo pipefail
+
+# Run at rvsol/
+
+DEPLOY_PRIVATE_KEY="${DEPLOY_PRIVATE_KEY:-"0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"}" # foundry pre-funded account #1
+ASTERISC_PRESTATE="${ASTERISC_PRESTATE:-"/../rvgo/bin/prestate-proof.json"}"
+
+if [ -z "${TARGET_L2_DEPLOYMENT_FILE}" ]; then
+    echo "TARGET_L2_DEPLOYMENT_FILE is not set. Must point target chain deployment file (optimism/packages/contracts-bedrock/deployments/devnetL1/.deploy)"
+    exit 1
+fi
+
+if [ -z "${TARGET_L2_DEPLOY_CONFIG}" ]; then
+    echo "TARGET_L2_DEPLOY_CONFIG is not set. Must point target chain deploy config file (optimism/packages/contracts-bedrock/deploy-config/devnetL1.json)"
+    exit 1
+fi
+
+if [ -z "${TARGET_L1_ALLOC}" ]; then
+    echo "TARGET_L1_ALLOC is not set. Must point target chain l1 alloc file."
+    exit 1
+fi
+
+forge script --chain-id 900 scripts/Deploy.s.sol --sig "run()" --private-key "$DEPLOY_PRIVATE_KEY"

--- a/rvsol/scripts/create_poststate_after_deployment.sh
+++ b/rvsol/scripts/create_poststate_after_deployment.sh
@@ -20,4 +20,4 @@ if [ -z "${TARGET_L1_ALLOC}" ]; then
     exit 1
 fi
 
-forge script --chain-id 900 scripts/Deploy.s.sol --sig "run()" --private-key "$DEPLOY_PRIVATE_KEY"
+forge script --chain-id 900 scripts/Deploy.s.sol --sig "runForDevnetAlloc()" --private-key "$DEPLOY_PRIVATE_KEY"


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

To run op-e2e, we need artifacts present at the test root. This patch creates L1 alloc which includes asterisc included, and asterisc contract's address.

To elaborate, we need these files from [here](https://github.com/ethereum-optimism/optimism/blob/069f9c22775805c851919a594de817c8843182b6/op-e2e/config/init.go#L49-L51):
```go
	defaultL1AllocsPath := filepath.Join(root, ".devnet", "allocs-l1.json")
	defaultL1DeploymentsPath := filepath.Join(root, ".devnet", "addresses.json")
	defaultDeployConfigPath := filepath.Join(root, "packages", "contracts-bedrock", "deploy-config", "devnetL1.json")
```

The newly added deployment scripts `create_poststate_after_deployment.sh` loads L1 alloc which did not had asterisc deployed, then deploy asterisc, and dump L1 alloc to json state.

