### PR TITLE
ci: make absolute prestate for asterisc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,10 @@ jobs:
           name: Copy FPAC allocs to .devnet-fpac
           command: cp -r .devnet/ .devnet-fault-proofs/
           working_directory: rvsol/lib/optimism
+      - run:
+          name: Generate non-FPAC allocs
+          command: make devnet-allocs
+          working_directory: rvsol/lib/optimism
       - persist_to_workspace:
           root: rvsol/lib/optimism
           paths:
@@ -89,6 +93,8 @@ jobs:
             - "packages/contracts-bedrock/tsconfig.build.tsbuildinfo"
             - ".devnet-fault-proofs/allocs-l1.json"
             - ".devnet-fault-proofs/addresses.json"
+            - ".devnet/allocs-l1.json"
+            - ".devnet/addresses.json"
             - "packages/contracts-bedrock/deploy-config/devnetL1.json"
             - "packages/contracts-bedrock/deployments/devnetL1"
 
@@ -235,4 +241,3 @@ jobs:
           root: .
           paths: 
             - "asterisc-artifacts"
-      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,238 @@
+version: 2.1
+
+parameters:
+  ci_builder_image:
+    type: string
+    # depends with rvsol/lib/optimism submodule version
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.46.1
+
+workflows:
+  main:
+    jobs:
+      - pnpm-monorepo
+      - go-mod-download-monorepo
+      - go-mod-download-asterisc
+      - op-program-riscv:
+          requires: ["go-mod-download-monorepo"]
+      - asterisc-prestate:
+          requires: ["go-mod-download-asterisc", "op-program-riscv", "pnpm-monorepo"]
+
+jobs:
+  pnpm-monorepo:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          name: Fetch submodules for asterisc
+          # This will also fetch monorepo's submodule.
+          # Therefore we do not have to call `make submodules` at monorepo root
+          command: git submodule update --init --recursive
+      - run:
+          name: Check L1 geth version
+          command: ./ops/scripts/geth-version-checker.sh || (echo "geth version is wrong, update ci-builder"; false)
+          working_directory: rvsol/lib/optimism
+      - restore_cache:
+          name: Restore PNPM Package Cache
+          keys:
+            - pnpm-packages-v2-{{ checksum "rvsol/lib/optimism/pnpm-lock.yaml" }}
+      - restore_cache:
+          name: Restore Go modules cache for monorepo
+          # this go mod cache will be populated from go-mod-download-monorepo step
+          key: gomod-{{ checksum "rvsol/lib/optimism/go.sum" }}
+      # Fetch node_modules into the pnpm store
+      # This will cache node_modules based on pnpm-lock so other steps can instantly install them with `pnpm install --prefer-offline`
+      # --prefer-offline installs node_modules instantly by just reading from cache if it exists rather than fetching from network
+      # when installing node_modules pnpm simply adds symlinks instead of copying the files which is why it is pretty much instant to run --prefer-offline
+      # this allows a caching strategy of only checking pnpm-lockfile so we don't have to keep it in sync with our packages
+      # For more information see https://pnpm.io/cli/fetch
+      - run:
+          name: Fetch dependencies
+          command: pnpm fetch --frozen-lockfile --prefer-offline
+          working_directory: rvsol/lib/optimism
+      - save_cache:
+          name: Save PNPM Package Cache
+          key: pnpm-packages-v2-{{ checksum "rvsol/lib/optimism/pnpm-lock.yaml" }}
+          paths:
+            - "rvsol/lib/optimism/node_modules"
+      - run:
+          name: Install dependencies
+          command: pnpm install:ci:offline
+          working_directory: rvsol/lib/optimism
+      - run:
+          name: print forge version
+          command: forge --version
+          working_directory: rvsol/lib/optimism
+      - run:
+          name: Build monorepo
+          environment:
+            FOUNDRY_PROFILE: ci
+          command: pnpm build
+          working_directory: rvsol/lib/optimism
+      - run:
+          name: Generate FPAC allocs
+          command: DEVNET_FPAC="true" make devnet-allocs
+          working_directory: rvsol/lib/optimism
+      - run:
+          name: Copy FPAC allocs to .devnet-fpac
+          command: cp -r .devnet/ .devnet-fault-proofs/
+          working_directory: rvsol/lib/optimism
+      - persist_to_workspace:
+          root: rvsol/lib/optimism
+          paths:
+            - "packages/**/dist"
+            - "packages/contracts-bedrock/cache"
+            - "packages/contracts-bedrock/artifacts"
+            - "packages/contracts-bedrock/forge-artifacts"
+            - "packages/contracts-bedrock/tsconfig.tsbuildinfo"
+            - "packages/contracts-bedrock/tsconfig.build.tsbuildinfo"
+            - ".devnet-fault-proofs/allocs-l1.json"
+            - ".devnet-fault-proofs/addresses.json"
+            - "packages/contracts-bedrock/deploy-config/devnetL1.json"
+            - "packages/contracts-bedrock/deployments/devnetL1"
+
+  go-mod-download-monorepo:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    parameters:
+      file:
+        default: rvsol/lib/optimism/go.sum
+        description: The file name of checksum for restore_cache and save_cache.
+        type: string
+      key:
+        default: gomod
+        description: The key of restore_cache and save_cache.
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Fetch submodules for asterisc
+          command: git submodule update --init --recursive
+      - restore_cache:
+          key: << parameters.key >>-{{ checksum "<< parameters.file >>" }}
+          name: Restore Go modules cache
+      - run:
+          name: Sanity check go mod cache path
+          command: test "$(go env GOMODCACHE)" == "/go/pkg/mod" # yes, it's an odd path
+          working_directory: rvsol/lib/optimism
+      - run:
+          command: go mod download
+          name: Download Go module dependencies
+          working_directory: rvsol/lib/optimism
+      - run:
+          name: Go mod tidy
+          command: make mod-tidy && git diff --exit-code
+          working_directory: rvsol/lib/optimism
+      - run:
+          name: run Go linter
+          command: |
+            # Identify how many cores it defaults to
+            golangci-lint --help | grep concurrency
+            make lint-go
+          working_directory: rvsol/lib/optimism
+      - save_cache:
+          key: << parameters.key >>-{{ checksum "<< parameters.file >>" }}
+          name: Save Go modules cache
+          paths:
+            - "/go/pkg/mod"
+
+  go-mod-download-asterisc:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    parameters:
+      file:
+        default: go.sum
+        description: The file name of checksum for restore_cache and save_cache.
+        type: string
+      key:
+        default: gomod
+        description: The key of restore_cache and save_cache.
+        type: string
+    steps:
+      - checkout
+      - restore_cache:
+          key: << parameters.key >>-{{ checksum "<< parameters.file >>" }}
+          name: Restore Go modules cache
+      - run:
+          name: Sanity check go mod cache path
+          command: test "$(go env GOMODCACHE)" == "/go/pkg/mod" # yes, it's an odd path
+      - run:
+          command: go mod download
+          name: Download Go module dependencies
+      - save_cache:
+          key: << parameters.key >>-{{ checksum "<< parameters.file >>" }}
+          name: Save Go modules cache
+          paths:
+            - "/go/pkg/mod"
+
+  op-program-riscv:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    parameters:
+      file:
+        default: rvsol/lib/optimism/go.sum
+        description: The file name of checksum for restore_cache and save_cache.
+        type: string
+      key:
+        default: gomod
+        description: The key of restore_cache and save_cache.
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Fetch submodules for asterisc
+          command: git submodule update --init --recursive
+      - restore_cache:
+          key: << parameters.key >>-{{ checksum "<< parameters.file >>" }}
+          name: Restore Go modules cache
+      - run:
+          name: Build op-program-client-riscv
+          command: make op-program-client-riscv
+          working_directory: rvsol/lib/optimism/op-program
+      - run:
+          name: Copy op-program-client-riscv to op-program-artifacts
+          command: cp -r bin op-program-artifacts
+          working_directory: rvsol/lib/optimism/op-program
+      - persist_to_workspace:
+          root: rvsol/lib/optimism/op-program
+          paths:
+            - "op-program-artifacts"
+
+  asterisc-prestate:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    parameters:
+      file:
+        default: go.sum
+        description: The file name of checksum for restore_cache and save_cache.
+        type: string
+      key:
+        default: gomod
+        description: The key of restore_cache and save_cache.
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - restore_cache:
+          key: << parameters.key >>-{{ checksum "<< parameters.file >>" }}
+          name: Restore Go modules cache
+      - run:
+          name: Load op-program-client-riscv
+          command: |
+            cp /tmp/workspace/op-program-artifacts/op-program-client-riscv.elf op-program-client-riscv.elf
+      - run:
+          name: Build Asterisc binary and contract
+          command: make build
+      - run:
+          name: Generate asterisc prestate
+          command: OP_PROGRAM_PATH=./op-program-client-riscv.elf make prestate
+      - run:
+          name: Copy asterisc artifacts to asterisc-artifacts
+          command: cp -r rvgo/bin asterisc-artifacts
+      - persist_to_workspace:
+          root: .
+          paths: 
+            - "asterisc-artifacts"
+      


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds CI to calculate asterisc's absolute prestate, to prepare op-e2e tests for asterisc. To do this, 
1. Build op-program and compile op-program to riscv
2. Ask asterisc binary to create absolute prestate from op-program binary.

Example pipeline at [here](https://app.circleci.com/pipelines/github/ethereum-optimism/asterisc/56/workflows/103dea74-37ca-4f84-b6e8-c4c29b5ba953?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary):

<img width="909" alt="image" src="https://github.com/ethereum-optimism/asterisc/assets/29061389/fb0eda74-e7a6-4f4e-950f-3d61e7f4794e">




