### PR TITLE
Update optimism submodule version to 3d27411

### DIFF
--- a/rvsol/foundry.toml
+++ b/rvsol/foundry.toml
@@ -15,6 +15,7 @@ remappings = [
   'safe-contracts/=lib/optimism/packages/contracts-bedrock/lib/safe-contracts/contracts',
   'kontrol-cheatcodes/=lib/optimism/packages/contracts-bedrock/lib/kontrol-cheatcodes/src',
   'solady/=lib/optimism/packages/contracts-bedrock/lib/solady/src',
+  '@solady/=lib/optimism/packages/contracts-bedrock/lib/solady/src',
 
   # We need these remappings to use the Optimism monorepo contracts as a library.
   'src/dispute=lib/optimism/packages/contracts-bedrock/src/dispute',


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Update optimism submodule version to the current develop branch(https://github.com/ethereum-optimism/optimism/commit/3d27411a05472bc8eba15d93cfc4ba092d586bd6)
