### PR TITLE
test: Devnet Alloc for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ rvsol/deployments/devnetL1
 
 tests/go-tests/bin
 
+packages/contracts-bedrock
+.devnet
+
 # jetbrains
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ op-program-test-capture:
 op-program-riscv:
 	rm -rf $(MONOREPO_ROOT)/op-program/bin-riscv $(MONOREPO_ROOT)/op-program/bin
 	make -C $(MONOREPO_ROOT)/op-program op-program-client-riscv
+	# clear $(MONOREPO_ROOT)/op-program/bin to trigger `make cannon-prestate` at monorepo
 	mv $(MONOREPO_ROOT)/op-program/bin $(MONOREPO_ROOT)/op-program/bin-riscv
 .PHONY: op-program
 

--- a/Makefile
+++ b/Makefile
@@ -88,35 +88,8 @@ devnet-allocs-monorepo:
 	make -C $(MONOREPO_ROOT) devnet-allocs
 .PHONY: devnet-allocs-monorepo
 
-devnet-allocs: devnet-allocs-monorepo
-	cp -r $(MONOREPO_ROOT)/.devnet .devnet
-	mkdir -p packages/contracts-bedrock
-	cp -r $(MONOREPO_ROOT)/packages/contracts-bedrock/deploy-config packages/contracts-bedrock
-	mkdir -p packages/contracts-bedrock/deployments/devnetL1
-	cp -r $(MONOREPO_ROOT)/packages/contracts-bedrock/deployments/devnetL1 packages/contracts-bedrock/deployments
-	# Patch L1 Allocs
-	jq .accounts .devnet/allocs-l1.json > /tmp/allocs-l1-patched.json
-	# Generate L1 Allocs including asterisc
-	# copy everything locally due to foundry permission issues
-	cp ./rvgo/bin/prestate-proof.json ./rvsol/prestate-proof.json
-	cp -r packages/contracts-bedrock/deployments/devnetL1 ./rvsol/devnetL1
-	cp packages/contracts-bedrock/deploy-config/devnetL1.json ./rvsol/devnetL1.json
-	cp /tmp/allocs-l1-patched.json ./rvsol/allocs-l1-patched.json
-	cd ./rvsol && ASTERISC_PRESTATE=./prestate-proof.json \
-	TARGET_L2_DEPLOYMENT_FILE=./devnetL1/.deploy \
-	TARGET_L2_DEPLOY_CONFIG=./devnetL1.json \
-	TARGET_L1_ALLOC=./allocs-l1-patched.json \
-	DEPLOYMENT_OUTFILE=./deployments/devnetL1/.deploy \
-	STATE_DUMP_PATH=./allocs-l1-asterisc.json \
-	./scripts/create_poststate_after_deployment.sh
-	# Create address.json
-	jq -s '.[0] * .[1]' ./rvsol/devnetL1/.deploy ./rvsol/deployments/devnetL1/.deploy | tee .devnet/addresses.json
-	# Patch L1 Allocs: we need json as the form {"accounts": ... } for op-e2e
-	jq '{accounts: .}' ./rvsol/allocs-l1-asterisc.json > .devnet/allocs-l1.json
-	# Patch .deploy
-	cp .devnet/addresses.json packages/contracts-bedrock/deployments/devnetL1/.deploy
-	# Remove tmps
-	cd rvsol && rm -rf prestate-proof.json devnetL1 devnetL1.json allocs-l1-patched.json deployments ./allocs-l1-asterisc.json 
+devnet-allocs: devnet-allocs-monorepo prestate
+	./rvsol/scripts/devnet_allocs.sh
 .PHONY: devnet-allocs
 
 devnet-clean:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+MONOREPO_ROOT=./rvsol/lib/optimism
+
 build-rvgo:
 	make -C ./rvgo build
 .PHONY: build-rvgo
@@ -63,9 +65,9 @@ fuzz-mac:
   fuzz \
   fuzz-mac
 
-OP_PROGRAM_PATH ?= ./op-program-client-riscv.elf
+OP_PROGRAM_PATH ?= $(MONOREPO_ROOT)/op-program/bin-riscv/op-program-client-riscv.elf
 
-prestate: build-rvgo
+prestate: build-rvgo op-program-riscv
 	./rvgo/bin/asterisc load-elf --path $(OP_PROGRAM_PATH) --out ./rvgo/bin/prestate.json --meta ./rvgo/bin/meta.json
 	./rvgo/bin/asterisc run --proof-at '=0' --stop-at '=1' --input ./rvgo/bin/prestate.json --meta ./rvgo/bin/meta.json --proof-fmt './rvgo/bin/%d.json' --output ""
 	mv ./rvgo/bin/0.json ./rvgo/bin/prestate-proof.json
@@ -74,3 +76,50 @@ prestate: build-rvgo
 op-program-test-capture:
 	./tests/op-program-test/capture.sh
 .PHONY: op-program-test-capture
+
+op-program-riscv:
+	rm -rf $(MONOREPO_ROOT)/op-program/bin-riscv $(MONOREPO_ROOT)/op-program/bin
+	make -C $(MONOREPO_ROOT)/op-program op-program-client-riscv
+	mv $(MONOREPO_ROOT)/op-program/bin $(MONOREPO_ROOT)/op-program/bin-riscv
+.PHONY: op-program
+
+devnet-allocs-monorepo:
+	make -C $(MONOREPO_ROOT) devnet-allocs
+.PHONY: devnet-allocs-monorepo
+
+devnet-allocs: devnet-allocs-monorepo
+	cp -r $(MONOREPO_ROOT)/.devnet .devnet
+	mkdir -p packages/contracts-bedrock
+	cp -r $(MONOREPO_ROOT)/packages/contracts-bedrock/deploy-config packages/contracts-bedrock
+	mkdir -p packages/contracts-bedrock/deployments/devnetL1
+	cp -r $(MONOREPO_ROOT)/packages/contracts-bedrock/deployments/devnetL1 packages/contracts-bedrock/deployments
+	# Patch L1 Allocs
+	jq .accounts .devnet/allocs-l1.json > /tmp/allocs-l1-patched.json
+	# Generate L1 Allocs including asterisc
+	# copy everything locally due to foundry permission issues
+	cp ./rvgo/bin/prestate-proof.json ./rvsol/prestate-proof.json
+	cp -r packages/contracts-bedrock/deployments/devnetL1 ./rvsol/devnetL1
+	cp packages/contracts-bedrock/deploy-config/devnetL1.json ./rvsol/devnetL1.json
+	cp /tmp/allocs-l1-patched.json ./rvsol/allocs-l1-patched.json
+	cd ./rvsol && ASTERISC_PRESTATE=./prestate-proof.json \
+	TARGET_L2_DEPLOYMENT_FILE=./devnetL1/.deploy \
+	TARGET_L2_DEPLOY_CONFIG=./devnetL1.json \
+	TARGET_L1_ALLOC=./allocs-l1-patched.json \
+	DEPLOYMENT_OUTFILE=./deployments/devnetL1/.deploy \
+	STATE_DUMP_PATH=./allocs-l1-asterisc.json \
+	./scripts/create_poststate_after_deployment.sh
+	# Create address.json
+	jq -s '.[0] * .[1]' ./rvsol/devnetL1/.deploy ./rvsol/deployments/devnetL1/.deploy | tee .devnet/addresses.json
+	# Patch L1 Allocs: we need json as the form {"accounts": ... } for op-e2e
+	jq '{accounts: .}' ./rvsol/allocs-l1-asterisc.json > .devnet/allocs-l1.json
+	# Patch .deploy
+	cp .devnet/addresses.json packages/contracts-bedrock/deployments/devnetL1/.deploy
+	# Remove tmps
+	cd rvsol && rm -rf prestate-proof.json devnetL1 devnetL1.json allocs-l1-patched.json deployments ./allocs-l1-asterisc.json 
+.PHONY: devnet-allocs
+
+devnet-clean:
+	rm -rf .devnet
+	rm -rf packages/contracts-bedrock/deployments
+	rm -rf packages/contracts-bedrock/deploy-config
+.PHONY: devnet-clean

--- a/rvsol/scripts/devnet_allocs.sh
+++ b/rvsol/scripts/devnet_allocs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+MONOREPO_ROOT=./rvsol/lib/optimism
+
+cp -r ${MONOREPO_ROOT}/.devnet .devnet
+mkdir -p packages/contracts-bedrock
+cp -r ${MONOREPO_ROOT}/packages/contracts-bedrock/deploy-config packages/contracts-bedrock
+mkdir -p packages/contracts-bedrock/deployments/devnetL1
+cp -r ${MONOREPO_ROOT}/packages/contracts-bedrock/deployments/devnetL1 packages/contracts-bedrock/deployments
+# Patch L1 Allocs
+jq .accounts .devnet/allocs-l1.json > /tmp/allocs-l1-patched.json
+# Generate L1 Allocs including asterisc
+# copy everything locally due to foundry permission issues
+cp ./rvgo/bin/prestate-proof.json ./rvsol/prestate-proof.json
+cp -r packages/contracts-bedrock/deployments/devnetL1 ./rvsol/devnetL1
+cp packages/contracts-bedrock/deploy-config/devnetL1.json ./rvsol/devnetL1.json
+cp /tmp/allocs-l1-patched.json ./rvsol/allocs-l1-patched.json
+cd ./rvsol && ASTERISC_PRESTATE=./prestate-proof.json \
+TARGET_L2_DEPLOYMENT_FILE=./devnetL1/.deploy \
+TARGET_L2_DEPLOY_CONFIG=./devnetL1.json \
+TARGET_L1_ALLOC=./allocs-l1-patched.json \
+DEPLOYMENT_OUTFILE=./deployments/devnetL1/.deploy \
+STATE_DUMP_PATH=./allocs-l1-asterisc.json \
+./scripts/create_poststate_after_deployment.sh
+cd ..
+# Create address.json
+jq -s '.[0] * .[1]' ./rvsol/devnetL1/.deploy ./rvsol/deployments/devnetL1/.deploy | tee .devnet/addresses.json
+# Patch L1 Allocs: we need json as the form {"accounts": ... } for op-e2e
+jq '{accounts: .}' ./rvsol/allocs-l1-asterisc.json > .devnet/allocs-l1.json
+# Patch .deploy
+cp .devnet/addresses.json packages/contracts-bedrock/deployments/devnetL1/.deploy
+# Remove tmps
+cd rvsol && rm -rf prestate-proof.json devnetL1 devnetL1.json allocs-l1-patched.json deployments ./allocs-l1-asterisc.json


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds `make devnet-allocs` and other aux command to run op-e2e locally. Similar to `make devnet-allocs` at monorepo.

To cleanly build, run `make devnet-clean` then run `make devnet-allocs`.