### PR TITLE
rvgo: Fix inverted hint writing conditional check

### DIFF
--- a/rvgo/fast/state.go
+++ b/rvgo/fast/state.go
@@ -48,7 +48,7 @@ type VMState struct {
 	// to make sure pre-image requests can be served.
 	// The first 4 bytes are a uin32 length prefix.
 	// Warning: the hint MAY NOT BE COMPLETE. I.e. this is buffered,
-	// and should only be read when len(LastHint) > 4 && uint32(LastHint[:4]) >= len(LastHint[4:])
+	// and should only be read when len(LastHint) > 4 && uint32(LastHint[:4]) <= len(LastHint[4:])
 	LastHint hexutil.Bytes `json:"lastHint,omitempty"`
 
 	// VMState must hold these values because if not, we must ask FPVM again to

--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -461,7 +461,7 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 				s.LastHint = append(inst.state.LastHint, hintData...)
 				for len(s.LastHint) >= 4 { // process while there is enough data to check if there are any hints
 					hintLen := binary.BigEndian.Uint32(s.LastHint[:4])
-					if hintLen >= uint32(len(s.LastHint[4:])) {
+					if hintLen <= uint32(len(s.LastHint[4:])) {
 						hint := s.LastHint[4 : 4+hintLen] // without the length prefix
 						s.LastHint = s.LastHint[4+hintLen:]
 						inst.preimageOracle.Hint(hint)

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ethereum-optimism/asterisc/rvgo/slow"
 )
 
-var syscallInsn = []byte{0x73}
+var syscallInsn = []byte{0x73, 0x00, 0x00, 0x00}
 
 func staticOracle(t *testing.T, preimageData []byte) *testOracle {
 	return &testOracle{


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fix hint writing logic at `vm.go`. Equal bug compared with https://github.com/ethereum-optimism/optimism/pull/10514.

**Tests**

Mirrored unit test and fuzz test.

Ensured syscall instruction is 4 bytes written, for avoiding fuzz test failure.

