### PR TITLE
remove an impossible branch

### DIFF
--- a/rvgo/fast/memory.go
+++ b/rvgo/fast/memory.go
@@ -110,9 +110,6 @@ func (m *Memory) MerkleizeSubtree(gindex uint64) [32]byte {
 			return zeroHashes[64-5+1-l] // page does not exist
 		}
 	}
-	if l > PageKeySize+1 {
-		panic("cannot jump into intermediate node of page")
-	}
 	n, ok := m.nodes[gindex]
 	if !ok {
 		// if the node doesn't exist, the whole sub-tree is zeroed


### PR DESCRIPTION
If `l > PageKeySize+1` is true, it will already run into the `l > PageKeySize` branch above and return.