### PR TITLE
Convert rvgo's memory implementation to radix trie

### DIFF
--- a/docs/radix-memory.md
+++ b/docs/radix-memory.md
@@ -1,0 +1,115 @@
+# Benchmarking Radix Trie
+
+Asterisc moved away from its hashmap-based memory structure to a radix-trie based memory structure.
+
+This was done in order to:
+
+1. Improve client diversity by differentiating the implementation from cannon
+2. Improve runtime performance
+
+In radix trie, the branching factor and the depth of the trie is critical. Depending on the sparsity of the dataset, we must adjust the radix trie to best suit the program it runs.
+
+- Larger radix branching factors can lead to less levels and larger node sizes, which can lead to less pointer indirection and depth traversal while the larger node sizes leads to more memory footprint. Larger radix node also require more computation to generate a merkle root of a single node.
+- Smaller radix branching factors lead to more levels and smaller node sizes, which have contrary impact compared to above.
+
+There are two methods we used to benchmark the change to radix trie.
+
+Multiple variants of radix trie were tested, with different branching factors.
+
+Here’s the list of asterisc implemented with different configs:
+
+| Variant | Radix type |
+| --- | --- |
+| Asterisc v1.0.0 | non-radix |
+| Radix 1 | [4,4,4,4,4,4,4,8,8,8] - 10 levels |
+| Radix 2 | [8,8,8,8,8,8,4] - 7 levels |
+| Radix 3 | [4,4,4,4,4,4,4,4,4,4,4,4,4] - 13 levels |
+| Radix 4 | [8,8,8,8,8,4,4,4] - 8 levels |
+| Radix 5 | [16,16,6,6,4,4] - 6 levels |
+| Radix 6 | [16,16,6,6,4,2,2] - 7 levels |
+| Radix 7 | [10,10,10,10,12] - 5 levels |
+
+## Benchmark Unit Test
+
+New benchmark suite is added, which measures the latency of the following operations;
+
+- Memory read / write to random addresses
+- Memory read / write to contiguous address
+- Memory write to sparse memory addresse
+- Memory write to dense memory addresses
+- Merkle proof generation
+- Merkle root calculation
+
+For the above cases, each asterisc implementation had the following results:
+
+|  | Asteris v1.0.0 | Radix 1 | Radix 2 | Radix 3 | Radix 4 | Radix 5 | Radix 6 | Radix 7 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| RandomReadWrite | 17.9n | 15.96 | 15.62 | 16.58 | 15.82 | 16.2 | 18.98 | 15.89 |
+| SequentialReadWrite | 5.68n | 4.386 | 4.214 | 4.177 | 4.242 | 4.335 | 4.573 | 4.238 |
+| SparseMemoryUsage | 4.964µ | 5.845 | 6.317 | 5.187 | 5.93 | 4.954 | 8.265 | 24.567 |
+| DenseMemoryUsage | 11.73n | 9.094 | 9.649 | 10.11 | 10.12 | 10.4 | 10.12 | 10.12 |
+| MerkleProof | 1.97µ | 1.441 | 1.464 | 1.611 | 1.737 | 1.604 | 1.737 | 1.98 |
+| MerkleRoot | 6.129n | 4.536 | 4.52 | 4.509 | 4.648 | 4.623 | 4.746 | 4.928 |
+
+Above statistics are based on  `sec/op` . Most of the results show that radix-based implementation is faster than the previous hashmap-based memory, except for few outliers.
+
+Note that this does not account for memory usage such as `B/op` and `allocs/op`. As explained above, each initialization of radix-trie node allocates more memory than a hashmap would, leading to usually larger memory footprint.
+
+## Full op-program run
+
+For a more realistic performance of asterisc, we need to run it against the real chain data by running it as a VM client of op-program.
+
+Tests were done on Asterisc running with Kona, for op-sepolia at [block#17484899](https://sepolia-optimism.etherscan.io/block/17484899)
+
+|  | Average | Min | Max | % from v1.0.0 |
+| --- | --- | --- | --- | --- |
+| Asterisc v1.0.0 | 112.759 | 109.345 | 116.045 | 0.00% |
+| Radix 1 | 110.349 | 109.418 | 112.149 | -2.14% |
+| Radix 2 | 109.9 | 107.526 | 111.398 | -2.54% |
+| Radix 3 | 110.589 | 107.814 | 113.544 | -1.92% |
+| Radix 4 | 106.902 | 103.71 | 110.453 | -5.19% |
+| Radix 5 | 106.605 | 104.469 | 109.754 | -5.46% |
+| Radix 6 | 109.137 | 106.764 | 111.819 | -3.21% |
+| Radix 7 | 111.163 | 110.392 | 111.634 | -1.42% |
+| Radix 4 w/ pgo | 98.742 | 97.055 | 101.035 | -12.43% |
+
+As you can see above, radix 4/5 had the best results compared to original asterisc implementation, with more than 5% improvement in op-program run duration.
+
+After applying [pgo(profile-guided optimization)](https://go.dev/doc/pgo) on radix 4, we can observe over 12% improvement in speed.
+
+## Visualizing address allocation pattern
+
+In this radix-trie implementation, only the memory addresses that are actually allocatd are initialized as radix trie. Therefore, we can look at the overall memory allocation pattern to see how we can optimize the radix branching factor.
+
+| Radix level (4bit each) | Allocations |
+| --- | --- |
+| 1 | 2 |
+| 2 | 2 |
+| 3 | 2 |
+| 4 | 2 |
+| 5 | 2 |
+| 6 | 2 |
+| 7 | 2 |
+| 8 | 2 |
+| 9 | 2 |
+| 10 | 3 |
+| 11 | 33 |
+| 12 | 502 |
+| 13 | 7982 |
+
+Above graph is allocation count during a full op-program run, where the full address space(52 bits) are split into 13 nodes(4 bits each).
+
+We can observe that the memory allocation is very sparse in the upper parts of the memory address, while it is heavily dense in the lower part of the memory address.
+
+With only couple of allocation for 36bit-upper memory region, we could generalize that most of the op-program runs are confined to lower memory address regions.
+
+## Conclusion
+
+Based on above observations, and our goal of improving runtime performance, we decided on using `radix 5 (16, 16, 6, 6, 4, 4)`
+
+Usually, sparse region would utilize smaller branching factor for memory optimization. However, since our goal is faster performance, utilizing larger levels at upper memory region and reducing trie traversal depth.
+
+- use larger branching factors at the upper address level to reduce the trie traversal depth
+- use smaller branching factors at the lower address level to reduce computation for each node.
+
+In addition, we can apply pgo as mentioned above. To apply pgo to asterisc builds, we can run asterisc with cpu pprof enabled, and ship asterisc with `default.pgo` in the build path. This way, whenever the user builds Asterisc, pgo will be enabled by default, leading to addition 5+% improvement in speed.

--- a/rvgo/fast/memory.go
+++ b/rvgo/fast/memory.go
@@ -56,9 +56,9 @@ type Memory struct {
 }
 
 func NewMemory() *Memory {
+	node := &RadixNodeLevel1{}
 	return &Memory{
-		//nodes:         make(map[uint64]*[32]byte),
-		radix:         &RadixNodeLevel1{},
+		radix:         node,
 		pages:         make(map[uint64]*CachedPage),
 		branchFactors: [5]uint64{BF1, BF2, BF3, BF4, BF5},
 		lastPageKeys:  [2]uint64{^uint64(0), ^uint64(0)}, // default to invalid keys, to not match any pages

--- a/rvgo/fast/memory.go
+++ b/rvgo/fast/memory.go
@@ -38,16 +38,12 @@ var zeroHashes = func() [256][32]byte {
 }()
 
 type Memory struct {
-	// generalized index -> merkle root or nil if invalidated
-	// pageIndex -> cached page
-
-	pages map[uint64]*CachedPage
-
 	radix         *L1
-	branchFactors [10]uint64
+	branchFactors [6]uint64
 
 	// Note: since we don't de-alloc pages, we don't do ref-counting.
 	// Once a page exists, it doesn't leave memory
+	pages map[uint64]*CachedPage
 
 	// two caches: we often read instructions from one page, and do memory things with another page.
 	// this prevents map lookups each instruction
@@ -60,7 +56,7 @@ func NewMemory() *Memory {
 	return &Memory{
 		radix:         node,
 		pages:         make(map[uint64]*CachedPage),
-		branchFactors: [10]uint64{4, 4, 4, 4, 4, 4, 4, 8, 8, 8},
+		branchFactors: [6]uint64{16, 16, 6, 6, 4, 4},
 		lastPageKeys:  [2]uint64{^uint64(0), ^uint64(0)}, // default to invalid keys, to not match any pages
 	}
 }
@@ -201,7 +197,7 @@ func (m *Memory) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	m.branchFactors = [10]uint64{4, 4, 4, 4, 4, 4, 4, 8, 8, 8}
+	m.branchFactors = [6]uint64{16, 16, 6, 6, 4, 4}
 	m.radix = &L1{}
 	m.pages = make(map[uint64]*CachedPage)
 	m.lastPageKeys = [2]uint64{^uint64(0), ^uint64(0)}

--- a/rvgo/fast/memory.go
+++ b/rvgo/fast/memory.go
@@ -43,8 +43,8 @@ type Memory struct {
 
 	pages map[uint64]*CachedPage
 
-	radix         *RadixNodeLevel1
-	branchFactors [5]uint64
+	radix         *L1
+	branchFactors [10]uint64
 
 	// Note: since we don't de-alloc pages, we don't do ref-counting.
 	// Once a page exists, it doesn't leave memory
@@ -56,11 +56,11 @@ type Memory struct {
 }
 
 func NewMemory() *Memory {
-	node := &RadixNodeLevel1{}
+	node := &L1{}
 	return &Memory{
 		radix:         node,
 		pages:         make(map[uint64]*CachedPage),
-		branchFactors: [5]uint64{BF1, BF2, BF3, BF4, BF5},
+		branchFactors: [10]uint64{4, 4, 4, 4, 4, 4, 4, 8, 8, 8},
 		lastPageKeys:  [2]uint64{^uint64(0), ^uint64(0)}, // default to invalid keys, to not match any pages
 	}
 }
@@ -200,8 +200,9 @@ func (m *Memory) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &pages); err != nil {
 		return err
 	}
-	m.branchFactors = [5]uint64{BF1, BF2, BF3, BF4, BF5}
-	m.radix = &RadixNodeLevel1{}
+
+	m.branchFactors = [10]uint64{4, 4, 4, 4, 4, 4, 4, 8, 8, 8}
+	m.radix = &L1{}
 	m.pages = make(map[uint64]*CachedPage)
 	m.lastPageKeys = [2]uint64{^uint64(0), ^uint64(0)}
 	m.lastPage = [2]*CachedPage{nil, nil}

--- a/rvgo/fast/memory.go
+++ b/rvgo/fast/memory.go
@@ -200,7 +200,8 @@ func (m *Memory) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &pages); err != nil {
 		return err
 	}
-	//m.nodes = make(map[uint64]*[32]byte)
+	m.branchFactors = [5]uint64{BF1, BF2, BF3, BF4, BF5}
+	m.radix = &RadixNodeLevel1{}
 	m.pages = make(map[uint64]*CachedPage)
 	m.lastPageKeys = [2]uint64{^uint64(0), ^uint64(0)}
 	m.lastPage = [2]*CachedPage{nil, nil}

--- a/rvgo/fast/memory_benchmark_test.go
+++ b/rvgo/fast/memory_benchmark_test.go
@@ -1,0 +1,129 @@
+package fast
+
+import (
+	"math/rand"
+	"testing"
+)
+
+const (
+	smallDataset  = 1_000
+	mediumDataset = 100_000
+	largeDataset  = 1_000_000
+)
+
+func BenchmarkMemoryOperations(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		fn   func(b *testing.B, m *Memory)
+	}{
+		{"RandomReadWrite_Small", benchRandomReadWrite(smallDataset)},
+		{"RandomReadWrite_Medium", benchRandomReadWrite(mediumDataset)},
+		{"RandomReadWrite_Large", benchRandomReadWrite(largeDataset)},
+		{"SequentialReadWrite_Small", benchSequentialReadWrite(smallDataset)},
+		{"SequentialReadWrite_Large", benchSequentialReadWrite(largeDataset)},
+		{"SparseMemoryUsage", benchSparseMemoryUsage},
+		{"DenseMemoryUsage", benchDenseMemoryUsage},
+		{"SmallFrequentUpdates", benchSmallFrequentUpdates},
+		{"MerkleProofGeneration_Small", benchMerkleProofGeneration(smallDataset)},
+		{"MerkleProofGeneration_Large", benchMerkleProofGeneration(largeDataset)},
+		{"MerkleRootCalculation_Small", benchMerkleRootCalculation(smallDataset)},
+		{"MerkleRootCalculation_Large", benchMerkleRootCalculation(largeDataset)},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			m := NewMemory()
+			b.ResetTimer()
+			bm.fn(b, m)
+		})
+	}
+}
+
+func benchRandomReadWrite(size int) func(b *testing.B, m *Memory) {
+	return func(b *testing.B, m *Memory) {
+		addresses := make([]uint64, size)
+		for i := range addresses {
+			addresses[i] = rand.Uint64()
+		}
+		data := make([]byte, 8)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			addr := addresses[i%len(addresses)]
+			if i%2 == 0 {
+				m.SetUnaligned(addr, data)
+			} else {
+				m.GetUnaligned(addr, data)
+			}
+		}
+	}
+}
+
+func benchSequentialReadWrite(size int) func(b *testing.B, m *Memory) {
+	return func(b *testing.B, m *Memory) {
+		data := make([]byte, 8)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			addr := uint64(i % size)
+			if i%2 == 0 {
+				m.SetUnaligned(addr, data)
+			} else {
+				m.GetUnaligned(addr, data)
+			}
+		}
+	}
+}
+
+func benchSparseMemoryUsage(b *testing.B, m *Memory) {
+	data := make([]byte, 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addr := uint64(i) * 10_000_000 // Large gaps between addresses
+		m.SetUnaligned(addr, data)
+	}
+}
+
+func benchDenseMemoryUsage(b *testing.B, m *Memory) {
+	data := make([]byte, 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addr := uint64(i) * 8 // Contiguous 8-byte allocations
+		m.SetUnaligned(addr, data)
+	}
+}
+
+func benchSmallFrequentUpdates(b *testing.B, m *Memory) {
+	data := make([]byte, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addr := uint64(rand.Intn(1000000)) // Confined to a smaller range
+		m.SetUnaligned(addr, data)
+	}
+}
+
+func benchMerkleProofGeneration(size int) func(b *testing.B, m *Memory) {
+	return func(b *testing.B, m *Memory) {
+		// Setup: allocate some memory
+		for i := 0; i < size; i++ {
+			m.SetUnaligned(uint64(i)*8, []byte{byte(i)})
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			addr := uint64(rand.Intn(size) * 8)
+			_ = m.MerkleProof(addr)
+		}
+	}
+}
+
+func benchMerkleRootCalculation(size int) func(b *testing.B, m *Memory) {
+	return func(b *testing.B, m *Memory) {
+		// Setup: allocate some memory
+		for i := 0; i < size; i++ {
+			m.SetUnaligned(uint64(i)*8, []byte{byte(i)})
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = m.MerkleRoot()
+		}
+	}
+}

--- a/rvgo/fast/memory_test.go
+++ b/rvgo/fast/memory_test.go
@@ -24,14 +24,14 @@ func TestMemoryMerkleProof(t *testing.T) {
 	})
 	t.Run("fuller tree", func(t *testing.T) {
 		m := NewMemory()
-		m.SetUnaligned(0x10000, []byte{0xaa, 0xbb, 0xcc, 0xdd})
-		m.SetUnaligned(0x80004, []byte{42})
-		m.SetUnaligned(0x13370000, []byte{123})
+		m.SetUnaligned(0x1002221234200, []byte{0xaa, 0xbb, 0xcc, 0xdd})
+		m.SetUnaligned(0x8002212342204, []byte{42})
+		m.SetUnaligned(0x1337022212342000, []byte{123})
 		root := m.MerkleRoot()
-		proof := m.MerkleProof(0x80004)
+		proof := m.MerkleProof(0x8002212342204)
 		require.Equal(t, uint32(42<<24), binary.BigEndian.Uint32(proof[4:8]))
 		node := *(*[32]byte)(proof[:32])
-		path := uint32(0x80004) >> 5
+		path := 0x8002212342204 >> 5
 		for i := 32; i < len(proof); i += 32 {
 			sib := *(*[32]byte)(proof[i : i+32])
 			if path&1 != 0 {
@@ -77,28 +77,31 @@ func TestMemoryMerkleRoot(t *testing.T) {
 		root := m.MerkleRoot()
 		require.Equal(t, zeroHashes[64-5], root, "zero still")
 	})
-	t.Run("random few pages", func(t *testing.T) {
-		m := NewMemory()
-		m.SetUnaligned(PageSize*3, []byte{1})
-		m.SetUnaligned(PageSize*5, []byte{42})
-		m.SetUnaligned(PageSize*6, []byte{123})
-		p3 := m.MerkleizeSubtree((1 << PageKeySize) | 3)
-		p5 := m.MerkleizeSubtree((1 << PageKeySize) | 5)
-		p6 := m.MerkleizeSubtree((1 << PageKeySize) | 6)
-		z := zeroHashes[PageAddrSize-5]
-		r1 := HashPair(
-			HashPair(
-				HashPair(z, z),  // 0,1
-				HashPair(z, p3), // 2,3
-			),
-			HashPair(
-				HashPair(z, p5), // 4,5
-				HashPair(p6, z), // 6,7
-			),
-		)
-		r2 := m.MerkleizeSubtree(1 << (PageKeySize - 3))
-		require.Equal(t, r1, r2, "expecting manual page combination to match subtree merkle func")
-	})
+
+	//t.Run("random few pages", func(t *testing.T) {
+	//	m := NewMemory()
+	//	m.SetUnaligned(PageSize*3, []byte{1})
+	//	m.SetUnaligned(PageSize*5, []byte{42})
+	//	m.SetUnaligned(PageSize*6, []byte{123})
+	//	p3 := m.MerkleizeNode(m.radix, (1<<PageKeySize)|3, 0)
+	//	p5 := m.MerkleizeNode(m.radix, (1<<PageKeySize)|5, 0)
+	//	p6 := m.MerkleizeNode(m.radix, (1<<PageKeySize)|6, 0)
+	//	z := zeroHashes[PageAddrSize-5]
+	//	r1 := HashPair(
+	//		HashPair(
+	//			HashPair(z, z),  // 0,1
+	//			HashPair(z, p3), // 2,3
+	//		),
+	//		HashPair(
+	//			HashPair(z, p5), // 4,5
+	//			HashPair(p6, z), // 6,7
+	//		),
+	//	)
+	//	r2 := m.MerkleizeNode(m.radix, 1<<(PageKeySize-3), 0)
+	//	r3 := m.MerkleizeNode3(m.radix, 1, 0)
+	//	require.Equal(t, r1, r2, "expecting manual page combination to match subtree merkle func")
+	//	require.Equal(t, r3, r2, "expecting manual page combination to match subtree merkle func")
+	//})
 	t.Run("invalidate page", func(t *testing.T) {
 		m := NewMemory()
 		m.SetUnaligned(0xF000, []byte{0})

--- a/rvgo/fast/memory_test.go
+++ b/rvgo/fast/memory_test.go
@@ -295,34 +295,34 @@ func TestMemoryMerkleRoot(t *testing.T) {
 		require.Equal(t, zeroHashes[64-5], root, "zero still")
 	})
 
-	t.Run("random few pages", func(t *testing.T) {
-		m := NewMemory()
-		m.SetUnaligned(PageSize*3, []byte{1})
-		m.SetUnaligned(PageSize*5, []byte{42})
-		m.SetUnaligned(PageSize*6, []byte{123})
-
-		p0 := m.MerkleizeNodeLevel1(m.radix, 0, 8)
-		p1 := m.MerkleizeNodeLevel1(m.radix, 0, 9)
-		p2 := m.MerkleizeNodeLevel1(m.radix, 0, 10)
-		p3 := m.MerkleizeNodeLevel1(m.radix, 0, 11)
-		p4 := m.MerkleizeNodeLevel1(m.radix, 0, 12)
-		p5 := m.MerkleizeNodeLevel1(m.radix, 0, 13)
-		p6 := m.MerkleizeNodeLevel1(m.radix, 0, 14)
-		p7 := m.MerkleizeNodeLevel1(m.radix, 0, 15)
-
-		r1 := HashPair(
-			HashPair(
-				HashPair(p0, p1), // 0,1
-				HashPair(p2, p3), // 2,3
-			),
-			HashPair(
-				HashPair(p4, p5), // 4,5
-				HashPair(p6, p7), // 6,7
-			),
-		)
-		r2 := m.MerkleizeNodeLevel1(m.radix, 0, 1)
-		require.Equal(t, r1, r2, "expecting manual page combination to match subtree merkle func")
-	})
+	//t.Run("random few pages", func(t *testing.T) {
+	//	m := NewMemory()
+	//	m.SetUnaligned(PageSize*3, []byte{1})
+	//	m.SetUnaligned(PageSize*5, []byte{42})
+	//	m.SetUnaligned(PageSize*6, []byte{123})
+	//
+	//	p0 := m.MerkleizeNodeLevel1(m.radix, 0, 8)
+	//	p1 := m.MerkleizeNodeLevel1(m.radix, 0, 9)
+	//	p2 := m.MerkleizeNodeLevel1(m.radix, 0, 10)
+	//	p3 := m.MerkleizeNodeLevel1(m.radix, 0, 11)
+	//	p4 := m.MerkleizeNodeLevel1(m.radix, 0, 12)
+	//	p5 := m.MerkleizeNodeLevel1(m.radix, 0, 13)
+	//	p6 := m.MerkleizeNodeLevel1(m.radix, 0, 14)
+	//	p7 := m.MerkleizeNodeLevel1(m.radix, 0, 15)
+	//
+	//	r1 := HashPair(
+	//		HashPair(
+	//			HashPair(p0, p1), // 0,1
+	//			HashPair(p2, p3), // 2,3
+	//		),
+	//		HashPair(
+	//			HashPair(p4, p5), // 4,5
+	//			HashPair(p6, p7), // 6,7
+	//		),
+	//	)
+	//	r2 := m.MerkleizeNodeLevel1(m.radix, 0, 1)
+	//	require.Equal(t, r1, r2, "expecting manual page combination to match subtree merkle func")
+	//})
 
 	t.Run("invalidate page", func(t *testing.T) {
 		m := NewMemory()

--- a/rvgo/fast/memory_test.go
+++ b/rvgo/fast/memory_test.go
@@ -2,10 +2,10 @@ package fast
 
 import (
 	"bytes"
+	cryptorand "crypto/rand"
 	"encoding/binary"
 	"encoding/json"
 	"io"
-	"math/rand"
 	"strings"
 	"testing"
 
@@ -339,7 +339,7 @@ func TestMemoryReadWrite(t *testing.T) {
 	t.Run("large random", func(t *testing.T) {
 		m := NewMemory()
 		data := make([]byte, 20_000)
-		_, err := rand.Read(data[:])
+		_, err := cryptorand.Read(data[:])
 		require.NoError(t, err)
 		require.NoError(t, m.SetMemoryRange(0, bytes.NewReader(data)))
 		for _, i := range []uint64{0, 1, 2, 3, 4, 5, 6, 7, 1000, 3333, 4095, 4096, 4097, 20_000 - 32} {

--- a/rvgo/fast/memory_test.go
+++ b/rvgo/fast/memory_test.go
@@ -6,11 +6,135 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"io"
+	mathrand "math/rand"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+const (
+	smallDataset  = 1_000
+	mediumDataset = 100_000
+	largeDataset  = 1_000_000
+)
+
+func BenchmarkMemoryOperations(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		fn   func(b *testing.B, m *Memory)
+	}{
+		{"RandomReadWrite_Small", benchRandomReadWrite(smallDataset)},
+		{"RandomReadWrite_Medium", benchRandomReadWrite(mediumDataset)},
+		{"RandomReadWrite_Large", benchRandomReadWrite(largeDataset)},
+		{"SequentialReadWrite_Small", benchSequentialReadWrite(smallDataset)},
+		{"SequentialReadWrite_Large", benchSequentialReadWrite(largeDataset)},
+		{"SparseMemoryUsage", benchSparseMemoryUsage},
+		{"DenseMemoryUsage", benchDenseMemoryUsage},
+		{"SmallFrequentUpdates", benchSmallFrequentUpdates},
+		{"MerkleProofGeneration_Small", benchMerkleProofGeneration(smallDataset)},
+		{"MerkleProofGeneration_Large", benchMerkleProofGeneration(largeDataset)},
+		{"MerkleRootCalculation_Small", benchMerkleRootCalculation(smallDataset)},
+		{"MerkleRootCalculation_Large", benchMerkleRootCalculation(largeDataset)},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			m := NewMemory()
+			b.ResetTimer()
+			bm.fn(b, m)
+		})
+	}
+}
+
+func benchRandomReadWrite(size int) func(b *testing.B, m *Memory) {
+	return func(b *testing.B, m *Memory) {
+		addresses := make([]uint64, size)
+		for i := range addresses {
+			addresses[i] = mathrand.Uint64()
+		}
+		data := make([]byte, 8)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			addr := addresses[i%len(addresses)]
+			if i%2 == 0 {
+				m.SetUnaligned(addr, data)
+			} else {
+				m.GetUnaligned(addr, data)
+			}
+		}
+	}
+}
+
+func benchSequentialReadWrite(size int) func(b *testing.B, m *Memory) {
+	return func(b *testing.B, m *Memory) {
+		data := make([]byte, 8)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			addr := uint64(i % size)
+			if i%2 == 0 {
+				m.SetUnaligned(addr, data)
+			} else {
+				m.GetUnaligned(addr, data)
+			}
+		}
+	}
+}
+
+func benchSparseMemoryUsage(b *testing.B, m *Memory) {
+	data := make([]byte, 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addr := uint64(i) * 1000000 // Large gaps between addresses
+		m.SetUnaligned(addr, data)
+	}
+}
+
+func benchDenseMemoryUsage(b *testing.B, m *Memory) {
+	data := make([]byte, 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addr := uint64(i) * 8 // Contiguous 8-byte allocations
+		m.SetUnaligned(addr, data)
+	}
+}
+
+func benchSmallFrequentUpdates(b *testing.B, m *Memory) {
+	data := make([]byte, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addr := mathrand.Uint64() % 1000000 // Confined to a smaller range
+		m.SetUnaligned(addr, data)
+	}
+}
+
+func benchMerkleProofGeneration(size int) func(b *testing.B, m *Memory) {
+	return func(b *testing.B, m *Memory) {
+		// Setup: allocate some memory
+		for i := 0; i < size; i++ {
+			m.SetUnaligned(uint64(i)*8, []byte{byte(i)})
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			addr := uint64(mathrand.Intn(size) * 8)
+			_ = m.MerkleProof(addr)
+		}
+	}
+}
+
+func benchMerkleRootCalculation(size int) func(b *testing.B, m *Memory) {
+	return func(b *testing.B, m *Memory) {
+		// Setup: allocate some memory
+		for i := 0; i < size; i++ {
+			m.SetUnaligned(uint64(i)*8, []byte{byte(i)})
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = m.MerkleRoot()
+		}
+	}
+}
 
 func TestMemoryMerkleProof(t *testing.T) {
 	t.Run("nearly empty tree", func(t *testing.T) {

--- a/rvgo/fast/memory_test.go
+++ b/rvgo/fast/memory_test.go
@@ -2,10 +2,10 @@ package fast
 
 import (
 	"bytes"
-	"crypto/rand"
 	"encoding/binary"
 	"encoding/json"
 	"io"
+	"math/rand"
 	"strings"
 	"testing"
 
@@ -295,34 +295,34 @@ func TestMemoryMerkleRoot(t *testing.T) {
 		require.Equal(t, zeroHashes[64-5], root, "zero still")
 	})
 
-	//t.Run("random few pages", func(t *testing.T) {
-	//	m := NewMemory()
-	//	m.SetUnaligned(PageSize*3, []byte{1})
-	//	m.SetUnaligned(PageSize*5, []byte{42})
-	//	m.SetUnaligned(PageSize*6, []byte{123})
-	//
-	//	p0 := m.MerkleizeNodeLevel1(m.radix, 0, 8)
-	//	p1 := m.MerkleizeNodeLevel1(m.radix, 0, 9)
-	//	p2 := m.MerkleizeNodeLevel1(m.radix, 0, 10)
-	//	p3 := m.MerkleizeNodeLevel1(m.radix, 0, 11)
-	//	p4 := m.MerkleizeNodeLevel1(m.radix, 0, 12)
-	//	p5 := m.MerkleizeNodeLevel1(m.radix, 0, 13)
-	//	p6 := m.MerkleizeNodeLevel1(m.radix, 0, 14)
-	//	p7 := m.MerkleizeNodeLevel1(m.radix, 0, 15)
-	//
-	//	r1 := HashPair(
-	//		HashPair(
-	//			HashPair(p0, p1), // 0,1
-	//			HashPair(p2, p3), // 2,3
-	//		),
-	//		HashPair(
-	//			HashPair(p4, p5), // 4,5
-	//			HashPair(p6, p7), // 6,7
-	//		),
-	//	)
-	//	r2 := m.MerkleizeNodeLevel1(m.radix, 0, 1)
-	//	require.Equal(t, r1, r2, "expecting manual page combination to match subtree merkle func")
-	//})
+	t.Run("random few pages", func(t *testing.T) {
+		m := NewMemory()
+		m.SetUnaligned(PageSize*3, []byte{1})
+		m.SetUnaligned(PageSize*5, []byte{42})
+		m.SetUnaligned(PageSize*6, []byte{123})
+
+		p0 := m.radix.MerkleizeNode(0, 8)
+		p1 := m.radix.MerkleizeNode(0, 9)
+		p2 := m.radix.MerkleizeNode(0, 10)
+		p3 := m.radix.MerkleizeNode(0, 11)
+		p4 := m.radix.MerkleizeNode(0, 12)
+		p5 := m.radix.MerkleizeNode(0, 13)
+		p6 := m.radix.MerkleizeNode(0, 14)
+		p7 := m.radix.MerkleizeNode(0, 15)
+
+		r1 := HashPair(
+			HashPair(
+				HashPair(p0, p1), // 0,1
+				HashPair(p2, p3), // 2,3
+			),
+			HashPair(
+				HashPair(p4, p5), // 4,5
+				HashPair(p6, p7), // 6,7
+			),
+		)
+		r2 := m.MerkleRoot()
+		require.Equal(t, r1, r2, "expecting manual page combination to match subtree merkle func")
+	})
 
 	t.Run("invalidate page", func(t *testing.T) {
 		m := NewMemory()

--- a/rvgo/fast/radix.go
+++ b/rvgo/fast/radix.go
@@ -1,0 +1,486 @@
+package fast
+
+import (
+	"math/bits"
+)
+
+const (
+	// Define branching factors for each level
+	BF1 = 10
+	BF2 = 10
+	BF3 = 10
+	BF4 = 10
+	BF5 = 12
+)
+
+type RadixNode interface {
+	merkleize(m *Memory, addr, gindex uint64) [32]byte
+	//getChild(index uint64) RadixNode
+	//setChild(index uint64, child RadixNode)
+	invalidateHashes(branch uint64)
+}
+
+//func (n *baseRadixNode) invalidateHashes(branch uint64) {
+//	for index := branch + (1 << 10); index > 0; index /= 2 {
+//		n.HashCache[index] = false
+//		n.Hashes[index] = [32]byte{}
+//	}
+//}
+
+type RadixNodeLevel1 struct {
+	Children  [1 << BF1]*RadixNodeLevel2
+	Hashes    [2 * 1 << BF1][32]byte
+	HashCache [2 * 1 << BF1]bool
+}
+
+type RadixNodeLevel2 struct {
+	Children  [1 << BF2]*RadixNodeLevel3
+	Hashes    [2 * 1 << BF2][32]byte
+	HashCache [2 * 1 << BF2]bool
+}
+
+type RadixNodeLevel3 struct {
+	Children  [1 << BF3]*RadixNodeLevel4
+	Hashes    [2 * 1 << BF3][32]byte
+	HashCache [2 * 1 << BF3]bool
+}
+
+type RadixNodeLevel4 struct {
+	Children  [1 << BF4]*RadixNodeLevel5
+	Hashes    [2 * 1 << BF4][32]byte
+	HashCache [2 * 1 << BF4]bool
+}
+
+type RadixNodeLevel5 struct {
+	Hashes    [2 * 1 << BF5][32]byte
+	HashCache [2 * 1 << BF5]bool
+}
+
+func (n *RadixNodeLevel1) invalidateHashes(branch uint64) {
+	for index := branch + (1 << BF1); index > 0; index /= 2 {
+		n.HashCache[index] = false
+		n.Hashes[index] = [32]byte{}
+	}
+}
+func (n *RadixNodeLevel2) invalidateHashes(branch uint64) {
+	for index := branch + (1 << BF2); index > 0; index /= 2 {
+		n.HashCache[index] = false
+		n.Hashes[index] = [32]byte{}
+	}
+}
+func (n *RadixNodeLevel3) invalidateHashes(branch uint64) {
+	for index := branch + (1 << BF3); index > 0; index /= 2 {
+		n.HashCache[index] = false
+		n.Hashes[index] = [32]byte{}
+	}
+}
+func (n *RadixNodeLevel4) invalidateHashes(branch uint64) {
+	for index := branch + (1 << BF4); index > 0; index /= 2 {
+		n.HashCache[index] = false
+		n.Hashes[index] = [32]byte{}
+	}
+}
+
+func (n *RadixNodeLevel5) invalidateHashes(branch uint64) {
+	for index := branch + (1 << BF5); index > 0; index /= 2 {
+		n.HashCache[index] = false
+		n.Hashes[index] = [32]byte{}
+	}
+}
+
+func (m *Memory) Invalidate(addr uint64) {
+	// find page, and invalidate addr within it
+	if p, ok := m.pageLookup(addr >> PageAddrSize); ok {
+		prevValid := p.Ok[1]
+		p.Invalidate(addr & PageAddrMask)
+		if !prevValid { // if the page was already invalid before, then nodes to mem-root will also still be.
+			return
+		}
+	} else { // no page? nothing to invalidate
+		return
+	}
+
+	branchPaths := m.addressToBranchPath(addr)
+
+	currentLevel1 := m.radix
+
+	currentLevel1.invalidateHashes(branchPaths[0])
+	if currentLevel1.Children[branchPaths[0]] == nil {
+		return
+	}
+
+	currentLevel2 := currentLevel1.Children[branchPaths[0]]
+	currentLevel2.invalidateHashes(branchPaths[1])
+	if currentLevel2.Children[branchPaths[1]] == nil {
+		return
+	}
+
+	currentLevel3 := currentLevel2.Children[branchPaths[1]]
+	currentLevel3.invalidateHashes(branchPaths[2])
+	if currentLevel3.Children[branchPaths[2]] == nil {
+		return
+	}
+
+	currentLevel4 := currentLevel3.Children[branchPaths[2]]
+	currentLevel4.invalidateHashes(branchPaths[3])
+	if currentLevel4.Children[branchPaths[3]] == nil {
+		return
+	}
+
+	currentLevel5 := currentLevel4.Children[branchPaths[3]]
+	currentLevel5.invalidateHashes(branchPaths[4])
+}
+
+func (m *Memory) MerkleizeNodeLevel1(node *RadixNodeLevel1, addr, gindex uint64) [32]byte {
+	if gindex > 2*1<<BF1-1 {
+		return [32]byte{}
+	}
+
+	depth := uint64(bits.Len64(gindex))
+
+	if node.HashCache[gindex] {
+		if node.Hashes[gindex] == [32]byte{} {
+			return zeroHashes[64-5+1-depth]
+		} else {
+			return node.Hashes[gindex]
+		}
+	}
+
+	if gindex < 1<<BF1 {
+		left := m.MerkleizeNodeLevel1(node, addr, gindex<<1)
+		right := m.MerkleizeNodeLevel1(node, addr, (gindex<<1)|1)
+
+		r := HashPair(left, right)
+		node.Hashes[gindex] = r
+		node.HashCache[gindex] = true
+		return r
+	}
+
+	childIndex := gindex - 1<<BF1
+	if node.Children[childIndex] == nil {
+		return zeroHashes[64-5+1-depth]
+	}
+	addr <<= BF1
+	addr |= childIndex
+	return m.MerkleizeNodeLevel2(node.Children[childIndex], addr, 1)
+}
+
+func (m *Memory) MerkleizeNodeLevel2(node *RadixNodeLevel2, addr, gindex uint64) [32]byte {
+	if gindex > 2*1<<BF2 {
+		return [32]byte{}
+	}
+
+	depth := uint64(bits.Len64(gindex))
+
+	if node.HashCache[gindex] {
+		if node.Hashes[gindex] == [32]byte{} {
+			return zeroHashes[64-5+1-depth]
+		} else {
+			return node.Hashes[gindex]
+		}
+	}
+
+	if gindex < 1<<BF2 {
+		left := m.MerkleizeNodeLevel2(node, addr, gindex<<1)
+		right := m.MerkleizeNodeLevel2(node, addr, (gindex<<1)|1)
+
+		r := HashPair(left, right)
+		node.Hashes[gindex] = r
+		node.HashCache[gindex] = true
+		return r
+	}
+
+	childIndex := gindex - 1<<BF2
+	if node.Children[childIndex] == nil {
+		return zeroHashes[64-5+1-(depth+BF1)]
+	}
+
+	addr <<= BF2
+	addr |= childIndex
+	return m.MerkleizeNodeLevel3(node.Children[childIndex], addr, 1)
+}
+func (m *Memory) MerkleizeNodeLevel3(node *RadixNodeLevel3, addr, gindex uint64) [32]byte {
+	if gindex > 2*1<<BF3 {
+		return [32]byte{}
+	}
+
+	depth := uint64(bits.Len64(gindex))
+
+	if node.HashCache[gindex] {
+		if node.Hashes[gindex] == [32]byte{} {
+			return zeroHashes[64-5+1-depth]
+		} else {
+			return node.Hashes[gindex]
+		}
+	}
+
+	if gindex < 1<<BF3 {
+		left := m.MerkleizeNodeLevel3(node, addr, gindex<<1)
+		right := m.MerkleizeNodeLevel3(node, addr, (gindex<<1)|1)
+		r := HashPair(left, right)
+		node.Hashes[gindex] = r
+		node.HashCache[gindex] = true
+		return r
+	}
+
+	childIndex := gindex - 1<<BF3
+	if node.Children[childIndex] == nil {
+		return zeroHashes[64-5+1-(depth+BF1+BF2)]
+	}
+
+	addr <<= BF3
+	addr |= childIndex
+	return m.MerkleizeNodeLevel4(node.Children[childIndex], addr, 1)
+}
+
+func (m *Memory) MerkleizeNodeLevel4(node *RadixNodeLevel4, addr, gindex uint64) [32]byte {
+	if gindex > 2*1<<BF4 {
+		return [32]byte{}
+	}
+
+	depth := uint64(bits.Len64(gindex))
+
+	if node.HashCache[gindex] {
+		if node.Hashes[gindex] == [32]byte{} {
+			return zeroHashes[64-5+1-depth]
+		} else {
+			return node.Hashes[gindex]
+		}
+	}
+
+	if gindex < 1<<BF4 {
+		left := m.MerkleizeNodeLevel4(node, addr, gindex<<1)
+		right := m.MerkleizeNodeLevel4(node, addr, (gindex<<1)|1)
+
+		r := HashPair(left, right)
+		node.Hashes[gindex] = r
+		node.HashCache[gindex] = true
+		return r
+	}
+
+	childIndex := gindex - 1<<BF4
+	if node.Children[childIndex] == nil {
+		return zeroHashes[64-5+1-(depth+BF1+BF2+BF3)]
+	}
+
+	addr <<= BF4
+	addr |= childIndex
+	return m.MerkleizeNodeLevel5(node.Children[childIndex], addr, 1)
+}
+
+func (m *Memory) MerkleizeNodeLevel5(node *RadixNodeLevel5, addr, gindex uint64) [32]byte {
+	depth := uint64(bits.Len64(gindex))
+
+	if gindex >= (1 << BF5) {
+		pageIndex := (addr << BF5) | (gindex - (1 << BF5))
+		if p, ok := m.pages[pageIndex]; ok {
+			return p.MerkleRoot()
+		} else {
+			return zeroHashes[64-5+1-(depth+40)]
+		}
+	}
+
+	if node.HashCache[gindex] {
+		if node.Hashes[gindex] == [32]byte{} {
+			return zeroHashes[64-5+1-depth]
+		} else {
+			return node.Hashes[gindex]
+		}
+	}
+
+	left := m.MerkleizeNodeLevel5(node, addr, gindex<<1)
+	right := m.MerkleizeNodeLevel5(node, addr, (gindex<<1)|1)
+	r := HashPair(left, right)
+	node.Hashes[gindex] = r
+	node.HashCache[gindex] = true
+	return r
+
+}
+
+func (m *Memory) GenerateProof1(node *RadixNodeLevel1, addr, target uint64) [][32]byte {
+	var proofs [][32]byte
+
+	for idx := target + 1<<BF1; idx > 1; idx /= 2 {
+		sibling := idx ^ 1
+		proofs = append(proofs, m.MerkleizeNodeLevel1(node, addr, sibling))
+	}
+
+	return proofs
+}
+
+func (m *Memory) GenerateProof2(node *RadixNodeLevel2, addr, target uint64) [][32]byte {
+	var proofs [][32]byte
+
+	for idx := target + 1<<BF2; idx > 1; idx /= 2 {
+		sibling := idx ^ 1
+		proofs = append(proofs, m.MerkleizeNodeLevel2(node, addr, sibling))
+	}
+
+	return proofs
+}
+
+func (m *Memory) GenerateProof3(node *RadixNodeLevel3, addr, target uint64) [][32]byte {
+	var proofs [][32]byte
+
+	for idx := target + 1<<BF3; idx > 1; idx /= 2 {
+		sibling := idx ^ 1
+		proofs = append(proofs, m.MerkleizeNodeLevel3(node, addr, sibling))
+	}
+
+	return proofs
+}
+func (m *Memory) GenerateProof4(node *RadixNodeLevel4, addr, target uint64) [][32]byte {
+	var proofs [][32]byte
+
+	for idx := target + 1<<BF4; idx > 1; idx /= 2 {
+		sibling := idx ^ 1
+		proofs = append(proofs, m.MerkleizeNodeLevel4(node, addr, sibling))
+	}
+
+	return proofs
+}
+
+func (m *Memory) GenerateProof5(node *RadixNodeLevel5, addr, target uint64) [][32]byte {
+	var proofs [][32]byte
+
+	for idx := target + 1<<BF5; idx > 1; idx /= 2 {
+		sibling := idx ^ 1
+		proofs = append(proofs, m.MerkleizeNodeLevel5(node, addr, sibling))
+	}
+
+	return proofs
+}
+func (m *Memory) MerkleProof(addr uint64) (out [ProofLen * 32]byte) {
+	var proofs [][32]byte
+
+	branchPaths := m.addressToBranchPath(addr)
+
+	currentLevel1 := m.radix
+	branch1 := branchPaths[0]
+
+	proofs = m.GenerateProof1(currentLevel1, 0, branch1)
+
+	if currentLevel1.Children[branch1] == nil {
+		// append proofs
+	}
+
+	currentLevel2 := currentLevel1.Children[branch1]
+	branch2 := branchPaths[1]
+	//addr = branch1
+	proofs = append(m.GenerateProof2(currentLevel2, addr>>(pageKeySize-BF1), branch2), proofs...)
+
+	if currentLevel2.Children[branch2] == nil {
+		return
+	}
+
+	currentLevel3 := currentLevel2.Children[branch2]
+	branch3 := branchPaths[2]
+	//addr >>= BF2
+	//addr |= branch2
+	proofs = append(m.GenerateProof3(currentLevel3, addr>>(pageKeySize-BF1-BF2), branch3), proofs...)
+
+	if currentLevel3.Children[branch3] == nil {
+		return
+	}
+
+	currentLevel4 := currentLevel3.Children[branch3]
+	branch4 := branchPaths[3]
+	//addr >>= BF3
+	//addr |= branch3
+	proofs = append(m.GenerateProof4(currentLevel4, addr>>(pageKeySize-BF1-BF2-BF3), branch4), proofs...)
+
+	if currentLevel4.Children[branch4] == nil {
+		return
+	}
+
+	currentLevel5 := currentLevel4.Children[branch4]
+	branch5 := branchPaths[4]
+	//addr >>= BF4
+	//addr |= branch4
+	proofs = append(m.GenerateProof5(currentLevel5, addr>>(pageKeySize-BF1-BF2-BF3-BF4), branch5), proofs...)
+
+	//addr |= branch5
+	var subproofs [][32]byte
+	pageGindex := PageSize>>5 + (addr&PageAddrMask)>>5 //(1 << 7) | (addr & ((1 << 7) - 1))
+
+	for idx := pageGindex; idx > 1; idx /= 2 {
+		sibling := idx ^ 1
+		if p, ok := m.pages[addr>>PageAddrSize]; ok {
+			subproofs = append(subproofs, p.MerkleizeSubtree(uint64(sibling)))
+		} else {
+			subproofs = append(subproofs, zeroHashes[64-5+1-idx])
+		}
+
+	}
+	proofs = append(subproofs, proofs...)
+
+	if p, ok := m.pages[addr>>PageAddrSize]; ok {
+		proofs = append([][32]byte{p.MerkleizeSubtree(pageGindex)}, proofs...)
+	}
+	//
+	//for idx, proof := range proofs {
+	//	print(idx)
+	//	print(" : ")
+	//	print(string(proof[:]))
+	//	print("\n")
+	//}
+
+	// encode the proof
+	for i := 0; i < ProofLen; i++ {
+		copy(out[i*32:(i+1)*32], proofs[i][:])
+	}
+
+	return out
+}
+
+func (m *Memory) MerkleRoot() [32]byte {
+	return m.MerkleizeNodeLevel1(m.radix, 0, 1)
+}
+
+func (m *Memory) addressToBranchPath(addr uint64) []uint64 {
+	addr >>= PageAddrSize
+
+	path := make([]uint64, len(m.branchFactors))
+	for i := len(m.branchFactors) - 1; i >= 0; i-- {
+		bits := m.branchFactors[i]
+		mask := (1 << bits) - 1       // Create a mask for the current segment
+		path[i] = addr & uint64(mask) // Extract the segment using the mask
+		addr >>= bits                 // Shift the gindex to the right by the number of bits processed
+	}
+	return path
+}
+
+func (m *Memory) AllocPage(pageIndex uint64) *CachedPage {
+	p := &CachedPage{Data: new(Page)}
+	m.pages[pageIndex] = p
+
+	branchPaths := m.addressToBranchPath(pageIndex << PageAddrSize)
+
+	currentLevel1 := m.radix
+	branch1 := branchPaths[0]
+	if currentLevel1.Children[branch1] == nil {
+		currentLevel1.Children[branch1] = &RadixNodeLevel2{}
+	}
+	currentLevel2 := currentLevel1.Children[branch1]
+
+	branch2 := branchPaths[1]
+	if currentLevel2.Children[branch2] == nil {
+		currentLevel2.Children[branch2] = &RadixNodeLevel3{}
+	}
+	currentLevel3 := currentLevel2.Children[branch2]
+
+	branch3 := branchPaths[2]
+	if currentLevel3.Children[branch3] == nil {
+		currentLevel3.Children[branch3] = &RadixNodeLevel4{}
+	}
+	currentLevel4 := currentLevel3.Children[branch3]
+
+	branch4 := branchPaths[3]
+	if currentLevel4.Children[branch4] == nil {
+		currentLevel4.Children[branch4] = &RadixNodeLevel5{}
+	}
+
+	// For Level 5, we don't need to allocate a child node
+
+	return p
+}

--- a/rvgo/fast/radix.go
+++ b/rvgo/fast/radix.go
@@ -4,100 +4,73 @@ import (
 	"math/bits"
 )
 
-const (
-	// Define branching factors for each level
-	BF1 = 10
-	BF2 = 10
-	BF3 = 10
-	BF4 = 10
-	BF5 = 12
-)
-
-type RadixNodeLevel1 struct {
-	Children   [1 << BF1]*RadixNodeLevel2
-	Hashes     [1 << BF1][32]byte
-	HashExists [(1 << BF1) / 64]uint64
-	HashValid  [(1 << BF1) / 64]uint64
+type RadixNode interface {
+	InvalidateNode(addr uint64)
+	GenerateProof(addr uint64) [][32]byte
+	MerkleizeNode(addr, gindex uint64) [32]byte
 }
 
-type RadixNodeLevel2 struct {
-	Children   [1 << BF2]*RadixNodeLevel3
-	Hashes     [1 << BF2][32]byte
-	HashExists [(1 << BF2) / 64]uint64
-	HashValid  [(1 << BF2) / 64]uint64
+type SmallRadixNode[C RadixNode] struct {
+	Children   [1 << 4]*C
+	Hashes     [1 << 4][32]byte
+	HashExists uint16
+	HashValid  uint16
+	Depth      uint16
 }
 
-type RadixNodeLevel3 struct {
-	Children   [1 << BF3]*RadixNodeLevel4
-	Hashes     [1 << BF3][32]byte
-	HashExists [(1 << BF3) / 64]uint64
-	HashValid  [(1 << BF3) / 64]uint64
+type LargeRadixNode[C RadixNode] struct {
+	Children   [1 << 8]*C
+	Hashes     [1 << 8][32]byte
+	HashExists [(1 << 8) / 64]uint64
+	HashValid  [(1 << 8) / 64]uint64
+	Depth      uint16
 }
 
-type RadixNodeLevel4 struct {
-	Children   [1 << BF4]*RadixNodeLevel5
-	Hashes     [1 << BF4][32]byte
-	HashExists [(1 << BF4) / 64]uint64
-	HashValid  [(1 << BF4) / 64]uint64
+type L1 = SmallRadixNode[L2]
+type L2 = *SmallRadixNode[L3]
+type L3 = *SmallRadixNode[L4]
+type L4 = *SmallRadixNode[L5]
+type L5 = *SmallRadixNode[L6]
+type L6 = *SmallRadixNode[L7]
+type L7 = *SmallRadixNode[L8]
+type L8 = *LargeRadixNode[L9]
+type L9 = *LargeRadixNode[L10]
+type L10 = *LargeRadixNode[L11]
+type L11 = *Memory
+
+func (n *SmallRadixNode[C]) InvalidateNode(addr uint64) {
+	childIdx := addressToRadixPath(addr, n.Depth, 4)
+
+	branchIdx := (childIdx + 1<<4) / 2
+	for index := branchIdx; index > 0; index >>= 1 {
+		hashBit := index & 15
+		n.HashExists |= 1 << hashBit
+		n.HashValid &= ^(1 << hashBit)
+	}
+
+	if n.Children[childIdx] != nil {
+		(*n.Children[childIdx]).InvalidateNode(addr)
+	}
 }
 
-type RadixNodeLevel5 struct {
-	Hashes     [1 << BF5][32]byte
-	HashExists [(1 << BF5) / 64]uint64
-	HashValid  [(1 << BF5) / 64]uint64
-}
+func (n *LargeRadixNode[C]) InvalidateNode(addr uint64) {
+	childIdx := addressToRadixPath(addr, n.Depth, 8)
 
-func (n *RadixNodeLevel1) invalidateHashes(branch uint64) {
-	branch = (branch + 1<<BF1) / 2
-	for index := branch; index > 0; index >>= 1 {
+	branchIdx := (childIdx + 1<<8) / 2
+
+	for index := branchIdx; index > 0; index >>= 1 {
 		hashIndex := index >> 6
 		hashBit := index & 63
 		n.HashExists[hashIndex] |= 1 << hashBit
 		n.HashValid[hashIndex] &= ^(1 << hashBit)
 	}
-}
-func (n *RadixNodeLevel2) invalidateHashes(branch uint64) {
-	branch = (branch + 1<<BF2) / 2
-	for index := branch; index > 0; index >>= 1 {
-		hashIndex := index >> 6
-		hashBit := index & 63
-		n.HashExists[hashIndex] |= 1 << hashBit
-		n.HashValid[hashIndex] &= ^(1 << hashBit)
-	}
-}
-func (n *RadixNodeLevel3) invalidateHashes(branch uint64) {
-	branch = (branch + 1<<BF3) / 2
-	for index := branch; index > 0; index >>= 1 {
-		hashIndex := index >> 6
-		hashBit := index & 63
-		n.HashExists[hashIndex] |= 1 << hashBit
-		n.HashValid[hashIndex] &= ^(1 << hashBit)
 
-	}
-}
-func (n *RadixNodeLevel4) invalidateHashes(branch uint64) {
-	branch = (branch + 1<<BF4) / 2
-	for index := branch; index > 0; index >>= 1 {
-		hashIndex := index >> 6
-		hashBit := index & 63
-		n.HashExists[hashIndex] |= 1 << hashBit
-		n.HashValid[hashIndex] &= ^(1 << hashBit)
-
+	if n.Children[childIdx] != nil {
+		(*n.Children[childIdx]).InvalidateNode(addr)
 	}
 }
 
-func (n *RadixNodeLevel5) invalidateHashes(branch uint64) {
-	branch = (branch + 1<<BF5) / 2
-	for index := branch; index > 0; index >>= 1 {
-		hashIndex := index >> 6
-		hashBit := index & 63
-		n.HashExists[hashIndex] |= 1 << hashBit
-		n.HashValid[hashIndex] &= ^(1 << hashBit)
-
-	}
-}
-
-func (m *Memory) Invalidate(addr uint64) {
+func (m *Memory) InvalidateNode(addr uint64) {
 	// find page, and invalidate addr within it
 	if p, ok := m.pageLookup(addr >> PageAddrSize); ok {
 		prevValid := p.Ok[1]
@@ -108,365 +81,159 @@ func (m *Memory) Invalidate(addr uint64) {
 	} else { // no page? nothing to invalidate
 		return
 	}
-
-	branchPaths := m.addressToBranchPath(addr)
-
-	currentLevel1 := m.radix
-
-	currentLevel1.invalidateHashes(branchPaths[0])
-	if currentLevel1.Children[branchPaths[0]] == nil {
-		return
-	}
-
-	currentLevel2 := currentLevel1.Children[branchPaths[0]]
-	currentLevel2.invalidateHashes(branchPaths[1])
-	if currentLevel2.Children[branchPaths[1]] == nil {
-		return
-	}
-
-	currentLevel3 := currentLevel2.Children[branchPaths[1]]
-	currentLevel3.invalidateHashes(branchPaths[2])
-	if currentLevel3.Children[branchPaths[2]] == nil {
-		return
-	}
-
-	currentLevel4 := currentLevel3.Children[branchPaths[2]]
-	currentLevel4.invalidateHashes(branchPaths[3])
-	if currentLevel4.Children[branchPaths[3]] == nil {
-		return
-	}
-
-	currentLevel5 := currentLevel4.Children[branchPaths[3]]
-	currentLevel5.invalidateHashes(branchPaths[4])
 }
 
-func (m *Memory) MerkleizeNodeLevel1(node *RadixNodeLevel1, addr, gindex uint64) [32]byte {
-	depth := uint64(bits.Len64(gindex))
+func (n *SmallRadixNode[C]) GenerateProof(addr uint64) [][32]byte {
+	var proofs [][32]byte
+	path := addressToRadixPath(addr, n.Depth, 4)
 
-	if depth <= BF1 {
-		hashIndex := gindex >> 6
-		hashBit := gindex & 63
-
-		if (node.HashExists[hashIndex] & (1 << hashBit)) != 0 {
-			if (node.HashValid[hashIndex] & (1 << hashBit)) != 0 {
-				return node.Hashes[gindex]
-			} else {
-				left := m.MerkleizeNodeLevel1(node, addr, gindex<<1)
-				right := m.MerkleizeNodeLevel1(node, addr, (gindex<<1)|1)
-
-				r := HashPair(left, right)
-				node.Hashes[gindex] = r
-				node.HashValid[hashIndex] |= 1 << hashBit
-				return r
-			}
-		} else {
-			return zeroHashes[64-5+1-depth]
-		}
-	}
-
-	if depth > BF1<<1 {
-		panic("gindex too deep")
-	}
-
-	childIndex := gindex - 1<<BF1
-	if node.Children[childIndex] == nil {
-		return zeroHashes[64-5+1-depth]
-	}
-	addr <<= BF1
-	addr |= childIndex
-	return m.MerkleizeNodeLevel2(node.Children[childIndex], addr, 1)
-}
-
-func (m *Memory) MerkleizeNodeLevel2(node *RadixNodeLevel2, addr, gindex uint64) [32]byte {
-
-	depth := uint64(bits.Len64(gindex))
-
-	if depth <= BF2 {
-		hashIndex := gindex >> 6
-		hashBit := gindex & 63
-
-		if (node.HashExists[hashIndex] & (1 << hashBit)) != 0 {
-			if (node.HashValid[hashIndex] & (1 << hashBit)) != 0 {
-				return node.Hashes[gindex]
-			} else {
-				left := m.MerkleizeNodeLevel2(node, addr, gindex<<1)
-				right := m.MerkleizeNodeLevel2(node, addr, (gindex<<1)|1)
-
-				r := HashPair(left, right)
-				node.Hashes[gindex] = r
-				node.HashValid[hashIndex] |= 1 << hashBit
-				return r
-			}
-		} else {
-			return zeroHashes[64-5+1-(depth+BF1)]
-		}
-	}
-
-	if depth > BF2<<1 {
-		panic("gindex too deep")
-	}
-
-	childIndex := gindex - 1<<BF2
-	if node.Children[childIndex] == nil {
-		return zeroHashes[64-5+1-(depth+BF1)]
-	}
-
-	addr <<= BF2
-	addr |= childIndex
-	return m.MerkleizeNodeLevel3(node.Children[childIndex], addr, 1)
-}
-func (m *Memory) MerkleizeNodeLevel3(node *RadixNodeLevel3, addr, gindex uint64) [32]byte {
-
-	depth := uint64(bits.Len64(gindex))
-
-	if depth <= BF3 {
-		hashIndex := gindex >> 6
-		hashBit := gindex & 63
-
-		if (node.HashExists[hashIndex] & (1 << hashBit)) != 0 {
-			if (node.HashValid[hashIndex] & (1 << hashBit)) != 0 {
-				return node.Hashes[gindex]
-			} else {
-				left := m.MerkleizeNodeLevel3(node, addr, gindex<<1)
-				right := m.MerkleizeNodeLevel3(node, addr, (gindex<<1)|1)
-				r := HashPair(left, right)
-				node.Hashes[gindex] = r
-				node.HashValid[hashIndex] |= 1 << hashBit
-				return r
-			}
-		} else {
-			return zeroHashes[64-5+1-(depth+BF1+BF2)]
-		}
-	}
-
-	if depth > BF3<<1 {
-		panic("gindex too deep")
-	}
-
-	childIndex := gindex - 1<<BF3
-	if node.Children[childIndex] == nil {
-		return zeroHashes[64-5+1-(depth+BF1+BF2)]
-	}
-
-	addr <<= BF3
-	addr |= childIndex
-	return m.MerkleizeNodeLevel4(node.Children[childIndex], addr, 1)
-}
-
-func (m *Memory) MerkleizeNodeLevel4(node *RadixNodeLevel4, addr, gindex uint64) [32]byte {
-
-	depth := uint64(bits.Len64(gindex))
-
-	if depth <= BF4 {
-		hashIndex := gindex >> 6
-		hashBit := gindex & 63
-		if (node.HashExists[hashIndex] & (1 << hashBit)) != 0 {
-			if (node.HashValid[hashIndex] & (1 << hashBit)) != 0 {
-				return node.Hashes[gindex]
-			} else {
-				left := m.MerkleizeNodeLevel4(node, addr, gindex<<1)
-				right := m.MerkleizeNodeLevel4(node, addr, (gindex<<1)|1)
-
-				r := HashPair(left, right)
-				node.Hashes[gindex] = r
-				node.HashValid[hashIndex] |= 1 << hashBit
-				return r
-			}
-		} else {
-			return zeroHashes[64-5+1-(depth+BF1+BF2+BF3)]
-		}
-	}
-
-	if depth > BF4<<1 {
-		panic("gindex too deep")
-	}
-
-	childIndex := gindex - 1<<BF4
-	if node.Children[childIndex] == nil {
-		return zeroHashes[64-5+1-(depth+BF1+BF2+BF3)]
-	}
-
-	addr <<= BF4
-	addr |= childIndex
-	return m.MerkleizeNodeLevel5(node.Children[childIndex], addr, 1)
-}
-
-func (m *Memory) MerkleizeNodeLevel5(node *RadixNodeLevel5, addr, gindex uint64) [32]byte {
-	depth := uint64(bits.Len64(gindex))
-
-	if depth > BF5 {
-		pageIndex := (addr << BF5) | (gindex - (1 << BF5))
-		if p, ok := m.pages[pageIndex]; ok {
-			return p.MerkleRoot()
-		} else {
-			return zeroHashes[64-5+1-(depth+40)]
-		}
-	}
-
-	hashIndex := gindex >> 6
-	hashBit := gindex & 63
-
-	if (node.HashExists[hashIndex] & (1 << hashBit)) != 0 {
-		if (node.HashValid[hashIndex] & (1 << hashBit)) != 0 {
-			return node.Hashes[gindex]
-		} else {
-			left := m.MerkleizeNodeLevel5(node, addr, gindex<<1)
-			right := m.MerkleizeNodeLevel5(node, addr, (gindex<<1)|1)
-			r := HashPair(left, right)
-			node.Hashes[gindex] = r
-			node.HashValid[hashIndex] |= 1 << hashBit
-			return r
-		}
+	if n.Children[path] == nil {
+		proofs = zeroHashRange(0, 60-n.Depth-4)
 	} else {
-		return zeroHashes[64-5+1-(depth+40)]
+		proofs = (*n.Children[path]).GenerateProof(addr)
 	}
-}
-
-func (m *Memory) GenerateProof1(node *RadixNodeLevel1, addr, target uint64) [][32]byte {
-	var proofs [][32]byte
-
-	for idx := target + 1<<BF1; idx > 1; idx >>= 1 {
+	for idx := path + 1<<4; idx > 1; idx >>= 1 {
 		sibling := idx ^ 1
-		proofs = append(proofs, m.MerkleizeNodeLevel1(node, addr, sibling))
+		proofs = append(proofs, n.MerkleizeNode(addr>>(64-n.Depth), sibling))
 	}
 
 	return proofs
 }
 
-func (m *Memory) GenerateProof2(node *RadixNodeLevel2, addr, target uint64) [][32]byte {
+func (n *LargeRadixNode[C]) GenerateProof(addr uint64) [][32]byte {
 	var proofs [][32]byte
+	path := addressToRadixPath(addr, n.Depth, 8)
 
-	for idx := target + 1<<BF2; idx > 1; idx >>= 1 {
-		sibling := idx ^ 1
-		proofs = append(proofs, m.MerkleizeNodeLevel2(node, addr, sibling))
+	if n.Children[path] == nil {
+		proofs = zeroHashRange(0, 60-n.Depth-8)
+	} else {
+		proofs = (*n.Children[path]).GenerateProof(addr)
 	}
 
+	for idx := path + 1<<8; idx > 1; idx >>= 1 {
+		sibling := idx ^ 1
+		proofs = append(proofs, n.MerkleizeNode(addr>>(64-n.Depth), sibling))
+	}
 	return proofs
 }
 
-func (m *Memory) GenerateProof3(node *RadixNodeLevel3, addr, target uint64) [][32]byte {
-	var proofs [][32]byte
+func (m *Memory) GenerateProof(addr uint64) [][32]byte {
+	pageIndex := addr >> PageAddrSize
 
-	for idx := target + 1<<BF3; idx > 1; idx >>= 1 {
-		sibling := idx ^ 1
-		proofs = append(proofs, m.MerkleizeNodeLevel3(node, addr, sibling))
+	if p, ok := m.pages[pageIndex]; ok {
+		return p.GenerateProof(addr)
+	} else {
+		return zeroHashRange(0, 8)
 	}
-
-	return proofs
-}
-func (m *Memory) GenerateProof4(node *RadixNodeLevel4, addr, target uint64) [][32]byte {
-	var proofs [][32]byte
-
-	for idx := target + 1<<BF4; idx > 1; idx >>= 1 {
-		sibling := idx ^ 1
-		proofs = append(proofs, m.MerkleizeNodeLevel4(node, addr, sibling))
-	}
-
-	return proofs
 }
 
-func (m *Memory) GenerateProof5(node *RadixNodeLevel5, addr, target uint64) [][32]byte {
-	var proofs [][32]byte
+func (n *SmallRadixNode[C]) MerkleizeNode(addr, gindex uint64) [32]byte {
+	depth := uint16(bits.Len64(gindex))
 
-	for idx := target + 1<<BF5; idx > 1; idx >>= 1 {
-		sibling := idx ^ 1
-		proofs = append(proofs, m.MerkleizeNodeLevel5(node, addr, sibling))
+	if depth <= 4 {
+		hashBit := gindex & 15
+
+		if (n.HashExists & (1 << hashBit)) != 0 {
+			if (n.HashValid & (1 << hashBit)) != 0 {
+				return n.Hashes[gindex]
+			} else {
+				left := n.MerkleizeNode(addr, gindex<<1)
+				right := n.MerkleizeNode(addr, (gindex<<1)|1)
+
+				r := HashPair(left, right)
+				n.Hashes[gindex] = r
+				n.HashValid |= 1 << hashBit
+				return r
+			}
+		} else {
+			return zeroHashes[64-5+1-(depth+n.Depth)]
+		}
 	}
 
-	return proofs
+	if depth > 5 {
+		panic("gindex too deep")
+	}
+
+	childIndex := gindex - 1<<4
+	if n.Children[childIndex] == nil {
+		return zeroHashes[64-5+1-(depth+n.Depth)]
+	}
+	addr <<= 4
+	addr |= childIndex
+	return (*n.Children[childIndex]).MerkleizeNode(addr, 1)
+}
+
+func (n *LargeRadixNode[C]) MerkleizeNode(addr, gindex uint64) [32]byte {
+	depth := uint16(bits.Len64(gindex))
+
+	if depth <= 8 {
+		hashIndex := gindex >> 6
+		hashBit := gindex & 63
+		if (n.HashExists[hashIndex] & (1 << hashBit)) != 0 {
+			if (n.HashValid[hashIndex] & (1 << hashBit)) != 0 {
+				return n.Hashes[gindex]
+			} else {
+				left := n.MerkleizeNode(addr, gindex<<1)
+				right := n.MerkleizeNode(addr, (gindex<<1)|1)
+
+				r := HashPair(left, right)
+				n.Hashes[gindex] = r
+				n.HashValid[hashIndex] |= 1 << hashBit
+				return r
+			}
+		} else {
+			return zeroHashes[64-5+1-(depth+n.Depth)]
+		}
+	}
+
+	if depth > 8<<1 {
+		panic("gindex too deep")
+	}
+
+	childIndex := gindex - 1<<8
+	if n.Children[int(childIndex)] == nil {
+		return zeroHashes[64-5+1-(depth+n.Depth)]
+	}
+
+	addr <<= 8
+	addr |= childIndex
+	return (*n.Children[childIndex]).MerkleizeNode(addr, 1)
+}
+
+func (m *Memory) MerkleizeNode(addr, gindex uint64) [32]byte {
+	depth := uint64(bits.Len64(gindex))
+
+	pageIndex := addr
+	if p, ok := m.pages[pageIndex]; ok {
+		return p.MerkleRoot()
+	} else {
+		return zeroHashes[64-5+1-(depth-1+52)]
+	}
+}
+
+func (m *Memory) MerkleRoot() [32]byte {
+	return (*m.radix).MerkleizeNode(0, 1)
 }
 
 func (m *Memory) MerkleProof(addr uint64) [ProofLen * 32]byte {
-	var proofs [60][32]byte
-
-	branchPaths := m.addressToBranchPath(addr)
-
-	// Level 1
-	proofIndex := BF1
-	currentLevel1 := m.radix
-	branch1 := branchPaths[0]
-
-	levelProofs := m.GenerateProof1(currentLevel1, 0, branch1)
-	copy(proofs[60-proofIndex:60], levelProofs)
-
-	// Level 2
-	currentLevel2 := m.radix.Children[branchPaths[0]]
-	if currentLevel2 != nil {
-		branch2 := branchPaths[1]
-		proofIndex += BF2
-		levelProofs := m.GenerateProof2(currentLevel2, addr>>(PageAddrSize+BF5+BF4+BF3+BF2), branch2)
-		copy(proofs[60-proofIndex:60-proofIndex+BF2], levelProofs)
-	} else {
-		fillZeroHashes(proofs[:], 0, 60-proofIndex)
-		return encodeProofs(proofs)
-	}
-
-	// Level 3
-	currentLevel3 := m.radix.Children[branchPaths[0]].Children[branchPaths[1]]
-	if currentLevel3 != nil {
-		branch3 := branchPaths[2]
-		proofIndex += BF3
-		levelProofs := m.GenerateProof3(currentLevel3, addr>>(PageAddrSize+BF5+BF4+BF3), branch3)
-		copy(proofs[60-proofIndex:60-proofIndex+BF3], levelProofs)
-	} else {
-		fillZeroHashes(proofs[:], 0, 60-proofIndex)
-		return encodeProofs(proofs)
-	}
-
-	// Level 4
-	currentLevel4 := m.radix.Children[branchPaths[0]].Children[branchPaths[1]].Children[branchPaths[2]]
-	if currentLevel4 != nil {
-		branch4 := branchPaths[3]
-		levelProofs := m.GenerateProof4(currentLevel4, addr>>(PageAddrSize+BF5+BF4), branch4)
-		proofIndex += BF4
-		copy(proofs[60-proofIndex:60-proofIndex+BF4], levelProofs)
-	} else {
-		fillZeroHashes(proofs[:], 0, 60-proofIndex)
-		return encodeProofs(proofs)
-	}
-
-	// Level 5
-	currentLevel5 := m.radix.Children[branchPaths[0]].Children[branchPaths[1]].Children[branchPaths[2]].Children[branchPaths[3]]
-	if currentLevel5 != nil {
-		branch5 := branchPaths[4]
-		levelProofs := m.GenerateProof5(currentLevel5, addr>>(PageAddrSize+BF5), branch5)
-		proofIndex += BF5
-		copy(proofs[60-proofIndex:60-proofIndex+BF5], levelProofs)
-	} else {
-		fillZeroHashes(proofs[:], 0, 60-proofIndex)
-		return encodeProofs(proofs)
-	}
-
-	// Page-level proof
-	pageGindex := PageSize>>5 + (addr&PageAddrMask)>>5
-	pageIndex := addr >> PageAddrSize
-
-	proofIndex = 0
-	if p, ok := m.pages[pageIndex]; ok {
-		proofs[proofIndex] = p.MerkleizeSubtree(pageGindex)
-		for idx := pageGindex; idx > 1; idx >>= 1 {
-			sibling := idx ^ 1
-			proofIndex++
-			proofs[proofIndex] = p.MerkleizeSubtree(uint64(sibling))
-		}
-	} else {
-		fillZeroHashes(proofs[:], 0, 7)
-	}
+	proofs := m.radix.GenerateProof(addr)
 
 	return encodeProofs(proofs)
 }
 
-func fillZeroHashes(proofs [][32]byte, start, end int) {
+func zeroHashRange(start, end uint16) [][32]byte {
+	proofs := make([][32]byte, end-start)
 	if start == 0 {
 		proofs[0] = zeroHashes[0]
 		start++
 	}
-	for i := start; i <= end; i++ {
+	for i := start; i < end; i++ {
 		proofs[i] = zeroHashes[i-1]
 	}
+	return proofs
 }
 
-func encodeProofs(proofs [60][32]byte) [ProofLen * 32]byte {
+func encodeProofs(proofs [][32]byte) [ProofLen * 32]byte {
 	var out [ProofLen * 32]byte
 	for i := 0; i < ProofLen; i++ {
 		copy(out[i*32:(i+1)*32], proofs[i][:])
@@ -474,8 +241,15 @@ func encodeProofs(proofs [60][32]byte) [ProofLen * 32]byte {
 	return out
 }
 
-func (m *Memory) MerkleRoot() [32]byte {
-	return m.MerkleizeNodeLevel1(m.radix, 0, 1)
+func addressToRadixPath(addr uint64, position, count uint16) uint64 {
+	// Calculate the total shift amount
+	totalShift := PageAddrSize + 52 - position - count
+
+	// Shift the address to bring the desired bits to the LSB
+	addr >>= totalShift
+
+	// Extract the desired bits using a mask
+	return addr & ((1 << count) - 1)
 }
 
 func (m *Memory) addressToBranchPath(addr uint64) []uint64 {
@@ -496,44 +270,79 @@ func (m *Memory) AllocPage(pageIndex uint64) *CachedPage {
 	m.pages[pageIndex] = p
 
 	branchPaths := m.addressToBranchPath(pageIndex << PageAddrSize)
-
 	currentLevel1 := m.radix
 	branch1 := branchPaths[0]
-	if currentLevel1.Children[branch1] == nil {
-		node := &RadixNodeLevel2{}
-		currentLevel1.Children[branch1] = node
-
+	if (*currentLevel1).Children[branch1] == nil {
+		node := &SmallRadixNode[L3]{Depth: 4}
+		(*currentLevel1).Children[branch1] = &node
 	}
-	currentLevel1.invalidateHashes(branchPaths[0])
-	currentLevel2 := currentLevel1.Children[branch1]
+	currentLevel2 := (*currentLevel1).Children[branch1]
 
 	branch2 := branchPaths[1]
-	if currentLevel2.Children[branch2] == nil {
-		node := &RadixNodeLevel3{}
-		currentLevel2.Children[branch2] = node
+	if (*currentLevel2).Children[branch2] == nil {
+		node := &SmallRadixNode[L4]{Depth: 8}
+		(*currentLevel2).Children[branch2] = &node
 	}
-	currentLevel2.invalidateHashes(branchPaths[1])
-	currentLevel3 := currentLevel2.Children[branch2]
+	currentLevel3 := (*currentLevel2).Children[branch2]
 
 	branch3 := branchPaths[2]
-	if currentLevel3.Children[branch3] == nil {
-		node := &RadixNodeLevel4{}
-		currentLevel3.Children[branch3] = node
+	if (*currentLevel3).Children[branch3] == nil {
+		node := &SmallRadixNode[L5]{Depth: 12}
+		(*currentLevel3).Children[branch3] = &node
 	}
-	currentLevel3.invalidateHashes(branchPaths[2])
-	currentLevel4 := currentLevel3.Children[branch3]
+	currentLevel4 := (*currentLevel3).Children[branch3]
 
 	branch4 := branchPaths[3]
-	if currentLevel4.Children[branch4] == nil {
-		node := &RadixNodeLevel5{}
-		currentLevel4.Children[branch4] = node
+	if (*currentLevel4).Children[branch4] == nil {
+		node := &SmallRadixNode[L6]{Depth: 16}
+		(*currentLevel4).Children[branch4] = &node
 	}
-	currentLevel4.invalidateHashes(branchPaths[3])
+	currentLevel5 := (*currentLevel4).Children[branch4]
 
-	currentLevel5 := currentLevel4.Children[branchPaths[3]]
-	currentLevel5.invalidateHashes(branchPaths[4])
+	branch5 := branchPaths[4]
+	if (*currentLevel5).Children[branch5] == nil {
+		node := &SmallRadixNode[L7]{Depth: 20}
+		(*currentLevel5).Children[branch5] = &node
+	}
+	currentLevel6 := (*currentLevel5).Children[branch5]
 
-	// For Level 5, we don't need to allocate a child node
+	branch6 := branchPaths[5]
+	if (*currentLevel6).Children[branch6] == nil {
+		node := &SmallRadixNode[L8]{Depth: 24}
+		(*currentLevel6).Children[branch6] = &node
+	}
+	currentLevel7 := (*currentLevel6).Children[branch6]
+
+	branch7 := branchPaths[6]
+	if (*currentLevel7).Children[branch7] == nil {
+		node := &LargeRadixNode[L9]{Depth: 28}
+		(*currentLevel7).Children[branch7] = &node
+	}
+	currentLevel8 := (*currentLevel7).Children[branch7]
+
+	branch8 := branchPaths[7]
+	if (*currentLevel8).Children[branch8] == nil {
+		node := &LargeRadixNode[L10]{Depth: 36}
+		(*currentLevel8).Children[branch8] = &node
+	}
+	currentLevel9 := (*currentLevel8).Children[branch8]
+
+	branch9 := branchPaths[8]
+	if (*currentLevel9).Children[branch9] == nil {
+		node := &LargeRadixNode[L11]{Depth: 44}
+		(*currentLevel9).Children[branch9] = &node
+	}
+	currentLevel10 := (*currentLevel9).Children[branch9]
+
+	branch10 := branchPaths[9]
+
+	(*currentLevel10).Children[branch10] = &m
+
+	m.Invalidate(pageIndex << PageAddrSize)
 
 	return p
+}
+
+func (m *Memory) Invalidate(addr uint64) {
+	m.radix.InvalidateNode(addr)
 }


### PR DESCRIPTION
## Background

Currently, Asterisc's memory layout is constructed using merkle tree represented as hashmaps where keys are a generalized index and values are the merkle root of the sub-tree or the node.

This design is identical to Cannon, and has some room for improvements. Therefore, in order to make Asterisc more memory efficient, we propose modifying the memory layout as follows.

## Proposed Change

1. Modify Asterisc to use radix trie instead of hashmap.
Currently, the memory of asterisc is laid out as follows. 

```go
nodes map[uint64]*[32]byte
```

We can modify it to something like:

```go
type RadixNode struct {
	Children [1  << 12]*RadixNode
	Hash [1 << 12][32]byte		
	HashExists [(1 << 12) / 64]uint64
	HashValid  [(1 << 12) / 64]uint64

}
```

1. Tune the radix trie's branching factor.
In order to better accommodate the typical memory layout, we can use different branching factor at each level of the trie.

Because upper memory levels are more sparse and the pages tend to be adjacent, we can have lower branching factor at upper trie levels, and higher branching factory at lower trie levels. While this is subject to benchmarking and testing, something like this would be possible:

```
level 1: 10 bits
level 2: 10 bits
level 3: 10 bits
level 4: 10 bits
level 5: 12 bits

Page offset: 12 bits
```

The tradeoff will also have to take account the complexity of managing different branching factor. 

1. Implement merkleization of the trie.
2. Leverage the radix trie to do better cache invalidation.
Currently, we invalidate a node by traversing from the leaf node to the root node and nullifying each node.
For a radix trie with fixed branching factor, we can directly access each level and nullify them. Because there are less level to traverse through, it is also more efficient than a binary tree.

## Expected Result

With the proposed changes, we can see the following improvements to Asterisc.

1. More implementation diversity between Asterisc and Cannon. Currently, Cannon and Asterisc uses nearly the same code for their go vm memory. Introducing different memory management to Asterisc allows us to leverage a more thorough fault proof system.
2. Increased memory. Compared to binary trees, radix tries will have larger number of intermediate nodes compared to a binary tree
3. Improved performance. These performance improvements can be benchmarked.
    1. Avoiding sparse objects. Because there are multiple levels to the radix trie, spare memory will be not allocated. 
    2. When accessing the values of Go's hashmap, each access results in a key hash. In a radix trie, we can directly access each child node through their pointer.

## Impact on binary

- This change is breaking change to the golang implementation of the RISCV VM.
- This change has no impact on the proof system.
- This change has no impact on the solidity implementation of the RISCV VM.

## Detailed implementation

Consider a memory where 

- PageAddrSize = 12
- PageKeySize = 52
- BranchFactor = [10,10,10,10,12] // branching factor at each level of the radix trie

For an address 0x1234567890123ABC, we use the 0x1234567890123 as the page key, and 0xABC as the page address. Since we’re using radix tries to represent each page key, we can lay out the radix trie like following: 

0x1234567890123 = 0b0001001000110100010101100111100010010000000100100011

```jsx
root
  |
0x48 (binary 0001 0010 00)
  |
0x345 (binary 1101 0001 01)
  |
0x19E (binary 0110 0111 10)
  |
0x90 (binary 0010 0100 00)
  | 
0x123 (binary 0001 0010 0011)
```

Each node has children which can be up to `2^branchFactor` items. All of the children are merkleized to form a the root hash of the node.

For example, radix node `0x123` can have up to 2^12 items. From those 4096 items, we must create the binary merkle tree, with intermediate nodes of the binary merkle tree as well. This results in a total of 8191 merkle hash in one radix node. 

These intermediate merkle hash will be used in proof generation, thus need to be cached. Following is the definition for a radix node. 

To determine whether the hash is generated at a specific generalized index(gindex), we have `hashExists` which is a list of bits that is enabled when a value is set for that specific node.  `HashValid` is also a list of bits that is enabled when a valid hash is created at that position, and disabled when the node is invalidated. 

```go
type RadixNode struct {	
	Children [1  << 12]*RadixNode // 2 ^ branchFactor
	Hash [1 << 12][32]byte		
	HashExists [(1 << 12) / 64]uint64
	HashValid  [(1 << 12) / 64]uint64
}
```

### AllocPage

```go
func (m *Memory) AllocPage(pageIndex uint64) *CachedPage {
	p := &CachedPage{Data: new(Page)}
	m.pages[pageIndex] = p

	// allocate radix nodes related to this page
	branchPaths := m.gindexToBranchPath(pageIndex)
	current := m.radix

	for _, branch := range branchPaths {
		if current.Children[branch] == nil {
			current.Children[branch] = NewRadixNode()
		}
		current = current.Children[branch]
	}

	return p
}
```

When a page is allocated, we can create a new radix node for every path from the root node to the leaf radix node. 

Any other radix branch that is not initialized will be nil, and we can replace any nil branch with a pre-computed zeroHash. 

### Optimizing hash caches

Previously, we were using `nodes map[uint64]*[32]byte` as hashmap with a pointer value type, so we could denote: 

1. address not set = map’s key not set
2. address is set, but hash isn’t calculated = map’s value is nil
3. address is set, hash is set = map’s value is non-nil

However, with a list of cache with plain `[32]byte` type, we need separate structure to remember which hashes are set, and which are valid. 

Here, we have 

```go
	HashExists [(1 << 12) / 64]uint64
	HashValid  [(1 << 12) / 64]uint64
```

where

- `HashExists` stands for case b) in the above scenario. When the address is set through AllocPages, HashExists is turned on.
- `HashValid` stands for case c) in the above scenario. When the hash is calculated, HashValid is turned on.

In order to save space, these types are `[(1 << 12) / 64]uint64` where the whole node length (1 <<12) is divided among 64 equal uint64, where each node is identified a unique bit in the list of uint64. 

Since 1 << 12 is equally divided by 64, we can use the following calculations 

`hashIndex := gindex >> 6` : to get the index of the outer uint64’s index

`hashBit := gindex & 63` : to get the bit position in the uint64. 

### MerkleizeNode

The overall method of merkleizing the node doesn’t change. We are merkleizing the merkle tree with respect to a specific gindex. 

We start from gindex=1 (the top of the tree), to the bottom of the tree by incrementing the gindex by a factor of 2. This allows us to only traverse through the trie once vertically. 

Our merkle trie is composed of 5 separate levels of merkle node. 

Each individual merkle node may have different branching factor therefore different children/hashes. This will result in different statically determined types of merkle node. Each level will have specific merkleizeNode function. 

```go
const (
  // Branching factor at each level
  BF1 = 10 
)

func (m *Memory) MerkleizeNodeLevel1(node *RadixNode, addr, gindex uint64) [32]byte {
	depth := uint64(bits.Len64(gindex))

	// The node is inside this trie level
	if depth <= BF1 {
		hashIndex := gindex >> 6
		hashBit := gindex & 63

		if (node.HashExists[hashIndex] & (1 << hashBit)) != 0 {
			if (node.HashValid[hashIndex] & (1 << hashBit)) != 0 {
				return node.Hashes[gindex] // Valid hash is set
			} else {
				 // Within the radix node, traverse through the node via gindex to create the hash
				left := m.MerkleizeNodeLevel1(node, addr, gindex<<1)
				right := m.MerkleizeNodeLevel1(node, addr, (gindex<<1)|1)

				r := HashPair(left, right)
				node.Hashes[gindex] = r
				node.HashValid[hashIndex] |= 1 << hashBit
				return r
			}
		} else {
		  // The address is not used, so we can use pre-calculated zeroHash
			return zeroHashes[64-5+1-depth]
		}
	}

	// We are at the bottom of the radix node. The child of the bottom node is the radix node at next level, or pages.
	// At this point, we need the merkle root of this children, or the merkle roof of the page
	childIndex := gindex - 1<<BF1
	if node.Children[childIndex] == nil { // Branch not allocated is nil
		return zeroHashes[64-5+1-depth]
	}
	
	// When traversing through the radix trie, 
	// the children index are added up to create the address
	addr <<= BF1
	addr |= childIndex
	
	return m.MerkleizeNodeLevel2(node.Children[childIndex], addr, 1)
}
```

We can traverse down the radix nodes by creating a statically deterministic branch path from that address. 

- If the radix node does not exist, we can return zeroHashes for that given gindex.
- If the final radix node exists, we can look for the hashIndex which corresponds to the intermediate merkle hash in the binary tree.
    - If it exists, return the hash
    - If not, traverse through the trie via gindex, and create a merkle hashes and save it to the node.Hashes.

At the final radix level, the leaf nodes represent the pages. 

```go
func (m *Memory) MerkleizeNodeLevel5(node *RadixNodeLevel5, addr, gindex uint64) [32]byte {
	depth := uint64(bits.Len64(gindex))

  // The leaf nodes of the trie are actual pages. 
  // We can get the pageInex by adding the address and this specific gindex so far. 
	if gindex >= (1 << BF5) {
		pageIndex := (addr << BF5) | (gindex - (1 << BF5))
		if p, ok := m.pages[pageIndex]; ok {
			return p.MerkleRoot()
		} else {
			return zeroHashes[64-5+1-(depth+40)]
		}
	}

	if node.HashCache[gindex] {
		if node.Hashes[gindex] == [32]byte{} {
			return zeroHashes[64-5+1-depth]
		} else {
			return node.Hashes[gindex]
		}
	}

	left := m.MerkleizeNodeLevel5(node, addr, gindex<<1)
	right := m.MerkleizeNodeLevel5(node, addr, (gindex<<1)|1)
	r := HashPair(left, right)
	node.Hashes[gindex] = r
	node.HashCache[gindex] = true
	return r
}

```

### MerkleProof

When creating a proof for `0x1234567890123ABC` the flow is as follows:

- There are 5 levels of merkle trie and the page addr is `0xABC`

At each level of the merkle trie, we can go through each level of binary tree hash, and collect the sibling hash

```jsx
func (m *Memory) GenerateProof1(node *RadixNodeLevel1, addr, target uint64) [][32]byte {
	var proofs [][32]byte

  // The idx starts at (0x123 + 1 << 12)
  // then traverses down the binary tree by dividing by 2
	for idx := target + 1<<BF1; idx > 1; idx /= 2 {
		sibling := idx ^ 1
		proofs = append(proofs, m.MerkleizeNodeLevel1(node, addr, sibling))
	}

	return proofs
}
```

We can run the above code only once for every branch depth. 

### Invalidation

For invalidation, if address  `0x1234567890123ABC` is invalidated, we need to invalidate 5 radix node at each level, as well as all of the intermediate merkle hashes they have created. 

```go
func (n *RadixNodeLevel1) invalidateHashes(branch uint64) {
	branch = (branch + 1<<BF1) / 2
	for index := branch; index > 0; index >>= 1 {
		hashIndex := index >> 6
		hashBit := index & 63
		n.HashExists[hashIndex] |= 1 << hashBit
		n.HashValid[hashIndex] &= ^(1 << hashBit)
	}
}
```

## Tests and Benchmarks

This change should not break any of the existing tests.

We must benchmark for the following items:

- Memory Usage
- Time Complexity
- Cache Invalidation
- Merklization

See https://github.com/ethereum-optimism/asterisc/blob/6229f246175130e537a8c7fd1ac63b7a9bac303e/docs/radix-memory.md for detailed note on testing radix trie performance. 