### PR TITLE
Add support for F_GETFD in order to support go1.22+

### DIFF
--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -486,6 +486,26 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 			var out U64
 			var errCode U64
 			switch cmd {
+			case 0x1: // F_GETFD: get file descriptor flags
+				switch fd {
+				case 0: // stdin
+					out = toU64(0) // no flag set
+				case 1: // stdout
+					out = toU64(0) // no flag set
+				case 2: // stderr
+					out = toU64(0) // no flag set
+				case 3: // hint-read
+					out = toU64(0) // no flag set
+				case 4: // hint-write
+					out = toU64(0) // no flag set
+				case 5: // pre-image read
+					out = toU64(0) // no flag set
+				case 6: // pre-image write
+					out = toU64(0) // no flag set
+				default:
+					out = u64Mask()
+					errCode = toU64(0x4d) //EBADF
+				}
 			case 0x3: // F_GETFL: get file descriptor flags
 				switch fd {
 				case 0: // stdin

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -666,6 +666,26 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 			var out U64
 			var errCode U64
 			switch cmd.val() {
+			case 0x1: // F_GETFD: get file descriptor flags
+				switch fd.val() {
+				case 0: // stdin
+					out = toU64(0) // no flag set
+				case 1: // stdout
+					out = toU64(0) // no flag set
+				case 2: // stderr
+					out = toU64(0) // no flag set
+				case 3: // hint-read
+					out = toU64(0) // no flag set
+				case 4: // hint-write
+					out = toU64(0) // no flag set
+				case 5: // pre-image read
+					out = toU64(0) // no flag set
+				case 6: // pre-image write
+					out = toU64(0) // no flag set
+				default:
+					out = u64Mask()
+					errCode = toU64(0x4d) //EBADF
+				}
 			case 0x3: // F_GETFL: get file descriptor flags
 				switch fd.val() {
 				case 0: // stdin

--- a/rvgo/test/syscall_test.go
+++ b/rvgo/test/syscall_test.go
@@ -476,8 +476,17 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 		// Add 7 to fd to ensure fd > 6
 		testFcntl(t, fd+7, 3, pc, step, 0xFFFF_FFFF_FFFF_FFFF, 0x4d)
 
+		// Test F_GETFD
+		for _, fd := range []uint64{0, 1, 2, 3, 4, 5, 6} {
+			testFcntl(t, fd, 1, pc, step, 0, 0)
+		}
+
+		// Test F_GETFD for unsupported fds
+		// Add 7 to fd to ensure fd > 6
+		testFcntl(t, fd+7, 1, pc, step, 0xFFFF_FFFF_FFFF_FFFF, 0x4d)
+
 		// Test other commands
-		if cmd == 3 {
+		if cmd == 3 || cmd == 1 {
 			// Set arbitrary commands if cmd is F_GETFL
 			cmd = 4
 		}

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -994,6 +994,42 @@ contract RISCV {
                     let out := 0
                     let errCode := 0
                     switch cmd
+                    case 0x1 {
+                        // F_GETFD: get file descriptor flags
+                        switch fd
+                        case 0 {
+                            // stdin
+                            out := toU64(0) // no flag set
+                        }
+                        case 1 {
+                            // stdout
+                            out := toU64(0) // no flag set
+                        }
+                        case 2 {
+                            // stderr
+                            out := toU64(0) // no flag set
+                        }
+                        case 3 {
+                            // hint-read
+                            out := toU64(0) // no flag set
+                        }
+                        case 4 {
+                            // hint-write
+                            out := toU64(0) // no flag set
+                        }
+                        case 5 {
+                            // pre-image read
+                            out := toU64(0) // no flag set
+                        }
+                        case 6 {
+                            // pre-image write
+                            out := toU64(0) // no flag set
+                        }
+                        default {
+                            out := u64Mask()
+                            errCode := toU64(0x4d) //EBADF
+                        }
+                    }
                     case 0x3 {
                         // F_GETFL: get file descriptor flags
                         switch fd


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Optimism has recently updated its go version to go1.22. 
However, updating to go1.22 introduces an error in the vm: `cannot open standard fds`. This is because go added checks for standard file descriptors: https://github.com/golang/go/commit/d4dd1de19fcef835fca14ad8cb590dbfcf8e9859.

This can be fixed by adding support for handling F_GETFD in the vm. 

A corresponding PR for cannon is in https://github.com/ethereum-optimism/optimism/pull/12050

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**
- All existing test suites passes
- New fuzz tests for testing the correct behavior of F_GETFD 

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->
