### PR TITLE
rvgo: experimental no-alloc noescape merkle funcs

### DIFF
--- a/rvgo/fast/keccakfast.go
+++ b/rvgo/fast/keccakfast.go
@@ -1,0 +1,43 @@
+package fast
+
+import (
+	"reflect"
+	_ "unsafe" // we use go:linkname
+
+	"golang.org/x/crypto/sha3"
+)
+
+type keccakState struct {
+	a [25]uint64 // main state of the hash
+	// and other fields, unimportant
+}
+
+//go:noescape
+//go:linkname keccakReset golang.org/x/crypto/sha3.(*state).Reset
+func keccakReset(st *keccakState)
+
+//go:noescape
+//go:linkname keccakWrite golang.org/x/crypto/sha3.(*state).Write
+func keccakWrite(st *keccakState, p []byte) (n int, err error)
+
+//go:noescape
+//go:linkname keccakRead golang.org/x/crypto/sha3.(*state).Read
+func keccakRead(st *keccakState, out []byte) (n int, err error)
+
+// example of how to get access to a hasher where the call arguments do not escape to the heap
+var hasher = (*keccakState)(reflect.ValueOf(sha3.NewLegacyKeccak256()).UnsafePointer())
+
+func hashPair(left, right [32]byte) (out [32]byte) {
+	keccakReset(hasher)
+	_, _ = keccakWrite(hasher, left[:])
+	_, _ = keccakWrite(hasher, right[:])
+	_, _ = keccakRead(hasher, out[:])
+	return
+}
+
+func hash(data [64]byte) (out [32]byte) {
+	keccakReset(hasher)
+	_, _ = keccakWrite(hasher, data[:])
+	_, _ = keccakRead(hasher, out[:])
+	return
+}

--- a/rvgo/fast/memory.go
+++ b/rvgo/fast/memory.go
@@ -6,8 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
-
-	"github.com/ethereum/go-ethereum/crypto"
+	_ "unsafe"
 )
 
 // Note: 2**12 = 4 KiB, the minimum page-size in Unicorn for mmap
@@ -22,17 +21,11 @@ const (
 	ProofLen     = 64 - 4
 )
 
-func HashPair(left, right [32]byte) [32]byte {
-	out := crypto.Keccak256Hash(left[:], right[:])
-	//fmt.Printf("0x%x 0x%x -> 0x%x\n", left, right, out)
-	return out
-}
-
 var zeroHashes = func() [256][32]byte {
 	// empty parts of the tree are all zero. Precompute the hash of each full-zero range sub-tree level.
 	var out [256][32]byte
 	for i := 1; i < 256; i++ {
-		out[i] = HashPair(out[i-1], out[i-1])
+		out[i] = hashPair(out[i-1], out[i-1])
 	}
 	return out
 }()

--- a/rvgo/fast/memory_test.go
+++ b/rvgo/fast/memory_test.go
@@ -36,9 +36,9 @@ func TestMemoryMerkleProof(t *testing.T) {
 		for i := 32; i < len(proof); i += 32 {
 			sib := *(*[32]byte)(proof[i : i+32])
 			if path&1 != 0 {
-				node = HashPair(sib, node)
+				node = hashPair(sib, node)
 			} else {
-				node = HashPair(node, sib)
+				node = hashPair(node, sib)
 			}
 			path >>= 1
 		}
@@ -253,9 +253,9 @@ func verifyProof(t *testing.T, expectedRoot [32]byte, proof [ProofLen * 32]byte,
 	for i := 32; i < len(proof); i += 32 {
 		sib := *(*[32]byte)(proof[i : i+32])
 		if path&1 != 0 {
-			node = HashPair(sib, node)
+			node = hashPair(sib, node)
 		} else {
-			node = HashPair(node, sib)
+			node = hashPair(node, sib)
 		}
 		path >>= 1
 	}
@@ -310,14 +310,14 @@ func TestMemoryMerkleRoot(t *testing.T) {
 		p6 := m.radix.MerkleizeNode(0, 14)
 		p7 := m.radix.MerkleizeNode(0, 15)
 
-		r1 := HashPair(
-			HashPair(
-				HashPair(p0, p1), // 0,1
-				HashPair(p2, p3), // 2,3
+		r1 := hashPair(
+			hashPair(
+				hashPair(p0, p1), // 0,1
+				hashPair(p2, p3), // 2,3
 			),
-			HashPair(
-				HashPair(p4, p5), // 4,5
-				HashPair(p6, p7), // 6,7
+			hashPair(
+				hashPair(p4, p5), // 4,5
+				hashPair(p6, p7), // 6,7
 			),
 		)
 		r2 := m.MerkleRoot()

--- a/rvgo/fast/page.go
+++ b/rvgo/fast/page.go
@@ -3,8 +3,6 @@ package fast
 import (
 	"encoding/hex"
 	"fmt"
-
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 type Page [PageSize]byte
@@ -55,7 +53,7 @@ func (p *CachedPage) MerkleRoot() [32]byte {
 		if p.Ok[j] {
 			continue
 		}
-		p.Cache[j] = crypto.Keccak256Hash(p.Data[i : i+64])
+		p.Cache[j] = hash([64]byte(p.Data[i : i+64]))
 		//fmt.Printf("0x%x 0x%x -> 0x%x\n", p.Data[i:i+32], p.Data[i+32:i+64], p.Cache[j])
 		p.Ok[j] = true
 	}
@@ -66,7 +64,7 @@ func (p *CachedPage) MerkleRoot() [32]byte {
 		if p.Ok[j] {
 			continue
 		}
-		p.Cache[j] = HashPair(p.Cache[i], p.Cache[i+1])
+		p.Cache[j] = hashPair(p.Cache[i], p.Cache[i+1])
 		p.Ok[j] = true
 	}
 
@@ -100,11 +98,10 @@ func (p *CachedPage) MerkleizeNode(addr, gindex uint64) [32]byte {
 	return p.Cache[gindex]
 }
 
-func (p *CachedPage) GenerateProof(addr uint64) [][32]byte {
+func (p *CachedPage) GenerateProof(addr uint64, proofs *[8][32]byte) {
 	// Page-level proof
 	pageGindex := PageSize>>5 + (addr&PageAddrMask)>>5
 
-	proofs := make([][32]byte, 8)
 	proofIndex := 0
 
 	proofs[proofIndex] = p.MerkleizeSubtree(pageGindex)
@@ -114,6 +111,4 @@ func (p *CachedPage) GenerateProof(addr uint64) [][32]byte {
 		proofIndex++
 		proofs[proofIndex] = p.MerkleizeSubtree(uint64(sibling))
 	}
-
-	return proofs
 }

--- a/rvgo/fast/page_test.go
+++ b/rvgo/fast/page_test.go
@@ -17,11 +17,11 @@ func TestCachedPage(t *testing.T) {
 	require.Equal(t, expectedLeaf, node, "leaf nodes should not be hashed")
 
 	node = p.MerkleizeSubtree(gindex >> 1)
-	expectedParent := common.Hash(HashPair(zeroHashes[0], expectedLeaf))
+	expectedParent := common.Hash(hashPair(zeroHashes[0], expectedLeaf))
 	require.Equal(t, expectedParent, node, "can get the parent node")
 
 	node = p.MerkleizeSubtree(gindex >> 2)
-	expectedParentParent := common.Hash(HashPair(expectedParent, zeroHashes[1]))
+	expectedParentParent := common.Hash(hashPair(expectedParent, zeroHashes[1]))
 	require.Equal(t, expectedParentParent, node, "and the parent of the parent")
 
 	pre := p.MerkleRoot()

--- a/rvgo/fast/radix.go
+++ b/rvgo/fast/radix.go
@@ -160,8 +160,7 @@ func (m *Memory) GenerateProof(addr uint64, proofs [][32]byte) {
 	// number of proof for a page is 8
 	// 0: leaf page data, 7: page's root
 	if p, ok := m.pages[pageIndex]; ok {
-		pageProofs := p.GenerateProof(addr) // Generate proof from the page.
-		copy(proofs[:8], pageProofs)
+		p.GenerateProof(addr, (*[8][32]byte)(proofs[:8])) // Generate proof from the page.
 	} else {
 		fillZeroHashRange(proofs, 0, 8) // Return zero hashes if the page does not exist.
 	}
@@ -203,8 +202,8 @@ func (n *SmallRadixNode[C]) MerkleizeNode(addr, gindex uint64) [32]byte {
 			left := n.MerkleizeNode(addr, gindex<<1)
 			right := n.MerkleizeNode(addr, (gindex<<1)|1)
 
-			// Hash the pair and cache the result.
-			r := HashPair(left, right)
+			// hash the pair and cache the result.
+			r := hashPair(left, right)
 			n.Hashes[gindex] = r
 			n.HashValid |= 1 << hashBit
 			return r
@@ -249,8 +248,8 @@ func (n *MediumRadixNode[C]) MerkleizeNode(addr, gindex uint64) [32]byte {
 			left := n.MerkleizeNode(addr, gindex<<1)
 			right := n.MerkleizeNode(addr, (gindex<<1)|1)
 
-			// Hash the pair and cache the result.
-			r := HashPair(left, right)
+			// hash the pair and cache the result.
+			r := hashPair(left, right)
 			n.Hashes[gindex] = r
 			n.HashValid |= 1 << hashBit
 			return r
@@ -290,7 +289,7 @@ func (n *LargeRadixNode[C]) MerkleizeNode(addr, gindex uint64) [32]byte {
 			left := n.MerkleizeNode(addr, gindex<<1)
 			right := n.MerkleizeNode(addr, (gindex<<1)|1)
 
-			r := HashPair(left, right)
+			r := hashPair(left, right)
 			n.Hashes[gindex] = r
 			n.HashValid[hashIndex] |= 1 << hashBit
 			return r


### PR DESCRIPTION
**Description**

A little bit hacky. And makes the assumption there's only 1 concurrent hasher (this could be fixed by allocating a `keccakState` per Memory merkleization job, and passing it as typed function argument through the merkle functions).

- Share hasher, so hasher doesn't get re-allocated every hash call
- Tricks with `go:noescape`  and `go:linkname` to force it to not assume the function interface, and not allow any slice data to escape to the heap)

This essentially removes all the non-essential allocations from the merkleization work, in a bit of an unsafe non-recommended way, to see how much performance can improve with this kind of heap-analysis informed memory optimization.

Profiles of the benchmark show that it's only a little bit faster, even after removing a theorectical ~10 million object allocations.

Before:
![before](https://github.com/user-attachments/assets/bbc9adcc-6e9b-4c13-bcd7-d6819ccffddc)

After:
![after](https://github.com/user-attachments/assets/848458fc-e36e-4beb-b0b9-c2ed5d76bb60)

CPU:
Before:
```
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkMemoryOperations
BenchmarkMemoryOperations/RandomReadWrite_Small
BenchmarkMemoryOperations/RandomReadWrite_Small-32         	48573948	        23.16 ns/op
BenchmarkMemoryOperations/RandomReadWrite_Medium
BenchmarkMemoryOperations/RandomReadWrite_Medium-32        	   12456	    126946 ns/op
BenchmarkMemoryOperations/RandomReadWrite_Large
BenchmarkMemoryOperations/RandomReadWrite_Large-32         	    9952	    112717 ns/op
BenchmarkMemoryOperations/SequentialReadWrite_Small
BenchmarkMemoryOperations/SequentialReadWrite_Small-32     	231982236	         5.219 ns/op
BenchmarkMemoryOperations/SequentialReadWrite_Large
BenchmarkMemoryOperations/SequentialReadWrite_Large-32     	222372898	         5.442 ns/op
BenchmarkMemoryOperations/SparseMemoryUsage
BenchmarkMemoryOperations/SparseMemoryUsage-32             	  528241	      2216 ns/op
BenchmarkMemoryOperations/DenseMemoryUsage
BenchmarkMemoryOperations/DenseMemoryUsage-32              	141923272	         8.803 ns/op
BenchmarkMemoryOperations/SmallFrequentUpdates
BenchmarkMemoryOperations/SmallFrequentUpdates-32          	36277586	        32.13 ns/op
BenchmarkMemoryOperations/MerkleProofGeneration_Small
BenchmarkMemoryOperations/MerkleProofGeneration_Small-32   	  655786	      1573 ns/op
BenchmarkMemoryOperations/MerkleProofGeneration_Large
BenchmarkMemoryOperations/MerkleProofGeneration_Large-32   	  561040	      1985 ns/op
BenchmarkMemoryOperations/MerkleRootCalculation_Small
BenchmarkMemoryOperations/MerkleRootCalculation_Small-32   	224840816	         5.409 ns/op
BenchmarkMemoryOperations/MerkleRootCalculation_Large
BenchmarkMemoryOperations/MerkleRootCalculation_Large-32   	205111311	         5.721 ns/op
PASS
```

After:
```
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkMemoryOperations
BenchmarkMemoryOperations/RandomReadWrite_Small
BenchmarkMemoryOperations/RandomReadWrite_Small-32         	51766090	        21.48 ns/op
BenchmarkMemoryOperations/RandomReadWrite_Medium
BenchmarkMemoryOperations/RandomReadWrite_Medium-32        	   12172	    130552 ns/op
BenchmarkMemoryOperations/RandomReadWrite_Large
BenchmarkMemoryOperations/RandomReadWrite_Large-32         	   10000	    113670 ns/op
BenchmarkMemoryOperations/SequentialReadWrite_Small
BenchmarkMemoryOperations/SequentialReadWrite_Small-32     	223583344	         4.971 ns/op
BenchmarkMemoryOperations/SequentialReadWrite_Large
BenchmarkMemoryOperations/SequentialReadWrite_Large-32     	232579297	         5.322 ns/op
BenchmarkMemoryOperations/SparseMemoryUsage
BenchmarkMemoryOperations/SparseMemoryUsage-32             	  423361	      2386 ns/op
BenchmarkMemoryOperations/DenseMemoryUsage
BenchmarkMemoryOperations/DenseMemoryUsage-32              	145170620	         8.592 ns/op
BenchmarkMemoryOperations/SmallFrequentUpdates
BenchmarkMemoryOperations/SmallFrequentUpdates-32          	36379844	        30.87 ns/op
BenchmarkMemoryOperations/MerkleProofGeneration_Small
BenchmarkMemoryOperations/MerkleProofGeneration_Small-32   	  702778	      1490 ns/op
BenchmarkMemoryOperations/MerkleProofGeneration_Large
BenchmarkMemoryOperations/MerkleProofGeneration_Large-32   	  555963	      1900 ns/op
BenchmarkMemoryOperations/MerkleRootCalculation_Small
BenchmarkMemoryOperations/MerkleRootCalculation_Small-32   	233706420	         5.124 ns/op
BenchmarkMemoryOperations/MerkleRootCalculation_Large
BenchmarkMemoryOperations/MerkleRootCalculation_Large-32   	218443596	         5.557 ns/op
PASS
```

Heap-escape:
```
./keccakfast.go:17:6: cannot inline keccakReset: no function body
./keccakfast.go:21:6: cannot inline keccakWrite: no function body
./keccakfast.go:25:6: cannot inline keccakRead: no function body
./keccakfast.go:30:6: cannot inline hashPair: function too complex: cost 259 exceeds budget 80
./keccakfast.go:38:6: cannot inline hash: function too complex: cost 193 exceeds budget 80
./keccakfast.go:28:68: inlining call to sha3.NewLegacyKeccak256
./keccakfast.go:28:68: Before inlining: 
.   CALLFUNC hash.Hash tc(1) # keccakfast.go:28:68
./keccakfast.go:28:68: After inlining 
.   .   AS2 Def tc(1) # keccakfast.go:28:68
.   .   INLMARK # +keccakfast.go:28:68
.   INLCALL hash.Hash tc(1) # keccakfast.go:28:68
.   .   BLOCK tc(1) # keccakfast.go:28:68
.   .   .   DCL tc(1) # keccakfast.go:28:68
.   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:27
.   .   .   AS2 tc(1) # keccakfast.go:28:68
.   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:27
.   .   .   .   CONVIFACE Implicit hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   PTRLIT PTR-*sha3.state tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   .   STRUCTLIT sha3.state tc(1) # keccakfast.go:28:68 hashes.go:71:52
.   .   .   .   .   .   .   STRUCTKEY sha3.rate # keccakfast.go:28:68 hashes.go:71:53
.   .   .   .   .   .   .   .   LITERAL-136 int tc(1) # keccakfast.go:28:68 hashes.go:71:59
.   .   .   .   .   .   .   STRUCTKEY sha3.outputLen # keccakfast.go:28:68 hashes.go:71:64
.   .   .   .   .   .   .   .   LITERAL-32 int tc(1) # keccakfast.go:28:68 hashes.go:71:75
.   .   .   .   .   .   .   STRUCTKEY sha3.dsbyte # keccakfast.go:28:68 hashes.go:71:79
.   .   .   .   .   .   .   .   LITERAL-1 byte tc(1) # keccakfast.go:28:68 hashes.go:71:87
.   .   .   .   .   ADDR PTR-*uint8 tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   ADDR PTR-*uint8 tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   GOTO fast..i0 tc(1) # keccakfast.go:28:68
.   .   LABEL fast..i0 # keccakfast.go:28:68
.   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:27
./keccakfast.go:28:44: inlining call to reflect.ValueOf
./keccakfast.go:28:44: Before inlining: 
.   CALLFUNC reflect.Value tc(1) # keccakfast.go:28:44
.   .   CONVIFACE Implicit any tc(1) # keccakfast.go:28:68
.   .   .   PAREN hash.Hash tc(1) # keccakfast.go:28:68
.   .   .   .   .   AS2 Def tc(1) # keccakfast.go:28:68
.   .   .   .   .   INLMARK # +keccakfast.go:28:68
.   .   .   .   INLCALL hash.Hash tc(1) # keccakfast.go:28:68
.   .   .   .   .   BLOCK tc(1) # keccakfast.go:28:68
.   .   .   .   .   .   DCL tc(1) # keccakfast.go:28:68
.   .   .   .   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:27
.   .   .   .   .   .   AS2 tc(1) # keccakfast.go:28:68
.   .   .   .   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:27
.   .   .   .   .   .   .   CONVIFACE Implicit hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   .   .   .   PTRLIT PTR-*sha3.state tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   .   .   .   .   STRUCTLIT sha3.state tc(1) # keccakfast.go:28:68 hashes.go:71:52
.   .   .   .   .   .   .   .   .   .   STRUCTKEY sha3.rate # keccakfast.go:28:68 hashes.go:71:53
.   .   .   .   .   .   .   .   .   .   .   LITERAL-136 int tc(1) # keccakfast.go:28:68 hashes.go:71:59
.   .   .   .   .   .   .   .   .   .   STRUCTKEY sha3.outputLen # keccakfast.go:28:68 hashes.go:71:64
.   .   .   .   .   .   .   .   .   .   .   LITERAL-32 int tc(1) # keccakfast.go:28:68 hashes.go:71:75
.   .   .   .   .   .   .   .   .   .   STRUCTKEY sha3.dsbyte # keccakfast.go:28:68 hashes.go:71:79
.   .   .   .   .   .   .   .   .   .   .   LITERAL-1 byte tc(1) # keccakfast.go:28:68 hashes.go:71:87
.   .   .   .   .   .   .   .   ADDR PTR-*uint8 tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   .   .   .   ADDR PTR-*uint8 tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   .   GOTO fast..i0 tc(1) # keccakfast.go:28:68
.   .   .   .   .   LABEL fast..i0 # keccakfast.go:28:68
.   .   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:27
./keccakfast.go:28:44: After inlining 
.   .   .   DCL # keccakfast.go:28:44
.   .   .   .   NAME-reflect.i Class:PAUTO Offset:0 InlFormal OnStack Used any tc(1) # keccakfast.go:28:44 value.go:3262:14
.   .   AS2 Def tc(1) # keccakfast.go:28:44
.   .   .   NAME-reflect.i Class:PAUTO Offset:0 InlFormal OnStack Used any tc(1) # keccakfast.go:28:44 value.go:3262:14
.   .   .   CONVIFACE Implicit any tc(1) # keccakfast.go:28:68
.   .   .   .   PAREN hash.Hash tc(1) # keccakfast.go:28:68
.   .   .   .   .   .   AS2 Def tc(1) # keccakfast.go:28:68
.   .   .   .   .   .   INLMARK # +keccakfast.go:28:68
.   .   .   .   .   INLCALL hash.Hash tc(1) # keccakfast.go:28:68
.   .   .   .   .   .   BLOCK tc(1) # keccakfast.go:28:68
.   .   .   .   .   .   .   DCL tc(1) # keccakfast.go:28:68
.   .   .   .   .   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:27
.   .   .   .   .   .   .   AS2 tc(1) # keccakfast.go:28:68
.   .   .   .   .   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:27
.   .   .   .   .   .   .   .   CONVIFACE Implicit hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   .   .   .   .   PTRLIT PTR-*sha3.state tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   .   .   .   .   .   STRUCTLIT sha3.state tc(1) # keccakfast.go:28:68 hashes.go:71:52
.   .   .   .   .   .   .   .   .   .   .   STRUCTKEY sha3.rate # keccakfast.go:28:68 hashes.go:71:53
.   .   .   .   .   .   .   .   .   .   .   .   LITERAL-136 int tc(1) # keccakfast.go:28:68 hashes.go:71:59
.   .   .   .   .   .   .   .   .   .   .   STRUCTKEY sha3.outputLen # keccakfast.go:28:68 hashes.go:71:64
.   .   .   .   .   .   .   .   .   .   .   .   LITERAL-32 int tc(1) # keccakfast.go:28:68 hashes.go:71:75
.   .   .   .   .   .   .   .   .   .   .   STRUCTKEY sha3.dsbyte # keccakfast.go:28:68 hashes.go:71:79
.   .   .   .   .   .   .   .   .   .   .   .   LITERAL-1 byte tc(1) # keccakfast.go:28:68 hashes.go:71:87
.   .   .   .   .   .   .   .   .   ADDR PTR-*uint8 tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   .   .   .   .   ADDR PTR-*uint8 tc(1) # keccakfast.go:28:68 hashes.go:71:46
.   .   .   .   .   .   .   GOTO fast..i0 tc(1) # keccakfast.go:28:68
.   .   .   .   .   .   LABEL fast..i0 # keccakfast.go:28:68
.   .   .   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack hash.Hash tc(1) # keccakfast.go:28:68 hashes.go:71:27
.   .   DCL # keccakfast.go:28:44
.   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack reflect.Value tc(1) # keccakfast.go:28:44 value.go:3262:21
.   .   AS tc(1) # keccakfast.go:28:44
.   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack reflect.Value tc(1) # keccakfast.go:28:44 value.go:3262:21
.   .   INLMARK Index:1 # +keccakfast.go:28:44
.   INLCALL reflect.Value tc(1) # keccakfast.go:28:44
.   .   IF tc(1) # keccakfast.go:28:44 value.go:3263:2
.   .   .   EQ bool tc(1) # keccakfast.go:28:44 value.go:3263:7
.   .   .   .   NAME-reflect.i Class:PAUTO Offset:0 InlFormal OnStack Used any tc(1) # keccakfast.go:28:44 value.go:3262:14
.   .   .   .   NIL any tc(1) # keccakfast.go:28:44 value.go:3263:10
.   .   .   BLOCK tc(1) # keccakfast.go:28:44
.   .   .   .   AS2 tc(1) # keccakfast.go:28:44
.   .   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack reflect.Value tc(1) # keccakfast.go:28:44 value.go:3262:21
.   .   .   .   .   STRUCTLIT reflect.Value tc(1) # keccakfast.go:28:44 value.go:3264:15
.   .   .   .   GOTO fast..i1 tc(1) # keccakfast.go:28:44
.   .   BLOCK tc(1) # keccakfast.go:28:44
.   .   .   AS2 tc(1) # keccakfast.go:28:44
.   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack reflect.Value tc(1) # keccakfast.go:28:44 value.go:3262:21
.   .   .   .   CALLFUNC reflect.Value tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   .   .   .   NAME-reflect.i Class:PAUTO Offset:0 InlFormal OnStack Used any tc(1) # keccakfast.go:28:44 value.go:3262:14
.   .   .   GOTO fast..i1 tc(1) # keccakfast.go:28:44
.   .   LABEL fast..i1 # keccakfast.go:28:44
.   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack reflect.Value tc(1) # keccakfast.go:28:44 value.go:3262:21
./keccakfast.go:28:44: inlining call to reflect.unpackEface
./keccakfast.go:28:44: Before inlining: 
.   CALLFUNC reflect.Value tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   NAME-reflect.i Class:PAUTO Offset:0 InlFormal OnStack Used any tc(1) # keccakfast.go:28:44 value.go:3262:14
./keccakfast.go:28:44: After inlining 
.   .   .   DCL # keccakfast.go:28:44 value.go:3266:20
.   .   .   .   NAME-reflect.i Class:PAUTO Offset:0 Addrtaken InlFormal OnStack Used any tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:154:18
.   .   AS2 Def tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   .   NAME-reflect.i Class:PAUTO Offset:0 Addrtaken InlFormal OnStack Used any tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:154:18
.   .   .   NAME-reflect.i Class:PAUTO Offset:0 InlFormal OnStack Used any tc(1) # keccakfast.go:28:44 value.go:3262:14
.   .   DCL # keccakfast.go:28:44 value.go:3266:20
.   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack reflect.Value tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:154:25
.   .   AS tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack reflect.Value tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:154:25
.   .   INLMARK Index:2 # +keccakfast.go:28:44 value.go:3266:20
.   INLCALL reflect.Value tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   .   DCL # keccakfast.go:28:44 value.go:3266:20 value.go:155:2
.   .   .   .   NAME-reflect.e Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.EmptyInterface tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:155:2
.   .   AS Def tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:155:4
.   .   .   NAME-reflect.e Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.EmptyInterface tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:155:2
.   .   .   CONVNOP PTR-*abi.EmptyInterface tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:155:43
.   .   .   .   CONVNOP UNSAFEPTR-unsafe.Pointer tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:155:44
.   .   .   .   .   ADDR PTR-*any tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:155:44
.   .   .   .   .   .   NAME-reflect.i Class:PAUTO Offset:0 Addrtaken InlFormal OnStack Used any tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:154:18
.   .   .   DCL # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
.   .   .   .   NAME-reflect.t Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
.   .   AS Def tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:4
.   .   .   NAME-reflect.t Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
.   .   .   DOTPTR fast.Type PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:8
.   .   .   .   NAME-reflect.e Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.EmptyInterface tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:155:2
.   .   IF tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:158:2
.   .   .   EQ bool tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:158:7
.   .   .   .   NAME-reflect.t Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
.   .   .   .   NIL PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:158:10
.   .   .   BLOCK tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   .   .   AS2 tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack reflect.Value tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:154:25
.   .   .   .   .   STRUCTLIT reflect.Value tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:159:15
.   .   .   .   GOTO fast..i2 tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   .   DCL # keccakfast.go:28:44 value.go:3266:20 value.go:161:2
.   .   .   .   NAME-reflect.f Class:PAUTO Offset:0 InlLocal OnStack Used reflect.flag tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:2
.   .   AS Def tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:4
.   .   .   NAME-reflect.f Class:PAUTO Offset:0 InlLocal OnStack Used reflect.flag tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:2
.   .   .   CONV reflect.flag tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   .   .   CALLFUNC abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   .   .   .   METHEXPR fast.Kind FUNC-func(*abi.Type) abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:13
.   .   .   .   .   NAME-reflect.t Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
.   .   IF tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:2
.   .   .   CALLFUNC bool tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   .   .   .   METHEXPR fast.IfaceIndir FUNC-func(*abi.Type) bool tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:6
.   .   .   .   NAME-reflect.t Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
.   .   .   ASOP-OR AsOp:OR tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:163:5
.   .   .   .   NAME-reflect.f Class:PAUTO Offset:0 InlLocal OnStack Used reflect.flag tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:2
.   .   .   .   LITERAL-128 reflect.flag tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:163:8
.   .   BLOCK tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   .   AS2 tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack reflect.Value tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:154:25
.   .   .   .   STRUCTLIT reflect.Value tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:165:14
.   .   .   .   .   STRUCTKEY reflect.typ_ # keccakfast.go:28:44 value.go:3266:20 value.go:165:15
.   .   .   .   .   .   NAME-reflect.t Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
.   .   .   .   .   STRUCTKEY reflect.ptr # keccakfast.go:28:44 value.go:3266:20 value.go:165:19
.   .   .   .   .   .   DOTPTR fast.Data UNSAFEPTR-unsafe.Pointer tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:165:19
.   .   .   .   .   .   .   NAME-reflect.e Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.EmptyInterface tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:155:2
.   .   .   .   .   STRUCTKEY reflect.flag # keccakfast.go:28:44 value.go:3266:20 value.go:165:26
.   .   .   .   .   .   NAME-reflect.f Class:PAUTO Offset:0 InlLocal OnStack Used reflect.flag tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:2
.   .   .   GOTO fast..i2 tc(1) # keccakfast.go:28:44 value.go:3266:20
.   .   LABEL fast..i2 # keccakfast.go:28:44 value.go:3266:20
.   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack reflect.Value tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:154:25
./keccakfast.go:28:44: inlining call to abi.(*Type).Kind
./keccakfast.go:28:44: Before inlining: 
.   CALLFUNC abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   METHEXPR fast.Kind FUNC-func(*abi.Type) abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:13
.   .   NAME-reflect.t Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
./keccakfast.go:28:44: After inlining 
.   .   .   DCL # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   .   .   NAME-abi.t Class:PAUTO Offset:0 InlFormal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18 type.go:189:7
.   .   AS2 Def tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   .   NAME-abi.t Class:PAUTO Offset:0 InlFormal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18 type.go:189:7
.   .   .   NAME-reflect.t Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
.   .   INLMARK Index:3 # +keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   INLCALL abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   BLOCK tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   .   DCL tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18 type.go:189:23
.   .   .   AS2 tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18 type.go:189:23
.   .   .   .   AND abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18 type.go:189:45
.   .   .   .   .   DOTPTR fast.Kind_ abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18 type.go:189:38
.   .   .   .   .   .   NAME-abi.t Class:PAUTO Offset:0 InlFormal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18 type.go:189:7
.   .   .   .   .   LITERAL-31 abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18 type.go:189:47
.   .   .   GOTO fast..i3 tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   LABEL fast..i3 # keccakfast.go:28:44 value.go:3266:20 value.go:161:18
.   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:161:18 type.go:189:23
./keccakfast.go:28:44: inlining call to abi.(*Type).IfaceIndir
./keccakfast.go:28:44: Before inlining: 
.   CALLFUNC bool tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   .   METHEXPR fast.IfaceIndir FUNC-func(*abi.Type) bool tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:6
.   .   NAME-reflect.t Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
./keccakfast.go:28:44: After inlining 
.   .   .   DCL # keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   .   .   .   NAME-abi.t Class:PAUTO Offset:0 InlFormal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:199:7
.   .   AS2 Def tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   .   .   NAME-abi.t Class:PAUTO Offset:0 InlFormal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:199:7
.   .   .   NAME-reflect.t Class:PAUTO Offset:0 InlLocal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:157:2
.   .   INLMARK Index:4 # +keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   INLCALL bool tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   .   BLOCK tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   .   .   DCL tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack bool tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:199:29
.   .   .   AS2 tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   .   .   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack bool tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:199:29
.   .   .   .   EQ bool tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:200:33
.   .   .   .   .   AND abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:200:16
.   .   .   .   .   .   DOTPTR fast.Kind_ abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:200:10
.   .   .   .   .   .   .   NAME-abi.t Class:PAUTO Offset:0 InlFormal OnStack Used PTR-*abi.Type tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:199:7
.   .   .   .   .   .   LITERAL-32 abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:200:17
.   .   .   .   .   LITERAL-0 abi.Kind tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:200:36
.   .   .   GOTO fast..i4 tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   .   LABEL fast..i4 # keccakfast.go:28:44 value.go:3266:20 value.go:162:17
.   .   NAME-fast.~r0 Class:PAUTO Offset:0 InlFormal OnStack bool tc(1) # keccakfast.go:28:44 value.go:3266:20 value.go:162:17 type.go:199:29
./keccakfast.go:17:18: st does not escape
./keccakfast.go:21:18: st does not escape
./keccakfast.go:21:35: p does not escape
./keccakfast.go:25:17: st does not escape
./keccakfast.go:25:34: out does not escape
./keccakfast.go:31:13:[1] hashPair stmt: keccakReset(hasher)
./keccakfast.go:32:7:[1] hashPair stmt: _, _ = int(.autotmp_3), .autotmp_4
./keccakfast.go:32:7:[1] hashPair stmt: .autotmp_3, .autotmp_4 := keccakWrite(hasher, left[:])
./keccakfast.go:32:7:[1] hashPair stmt: var .autotmp_3 int
./keccakfast.go:32:7:[1] hashPair stmt: var .autotmp_4 error
./keccakfast.go:33:7:[1] hashPair stmt: _, _ = int(.autotmp_5), .autotmp_6
./keccakfast.go:33:7:[1] hashPair stmt: .autotmp_5, .autotmp_6 := keccakWrite(hasher, right[:])
./keccakfast.go:33:7:[1] hashPair stmt: var .autotmp_5 int
./keccakfast.go:33:7:[1] hashPair stmt: var .autotmp_6 error
./keccakfast.go:34:7:[1] hashPair stmt: _, _ = int(.autotmp_7), .autotmp_8
./keccakfast.go:34:7:[1] hashPair stmt: .autotmp_7, .autotmp_8 := keccakRead(hasher, out[:])
./keccakfast.go:34:7:[1] hashPair stmt: var .autotmp_7 int
./keccakfast.go:34:7:[1] hashPair stmt: var .autotmp_8 error
./keccakfast.go:35:2:[1] hashPair stmt: return 
./keccakfast.go:28:5:[1] init stmt: hasher = (*keccakState)(reflect.Value.UnsafePointer(~r0))
./keccakfast.go:28:44:[1] init stmt: reflect.i := ~r0
./keccakfast.go:28:44:[1] init stmt: var reflect.i any
./keccakfast.go:28:68:[1] init stmt:  := 
./keccakfast.go:28:68:[1] init stmt: <node inlmark>
./keccakfast.go:28:68:[1] init stmt: var ~r0 hash.Hash; ~r0 = &sha3.state{...}; goto .i0
./keccakfast.go:28:68:[1] init stmt: var ~r0 hash.Hash
./keccakfast.go:28:68:[1] init stmt: ~r0 = &sha3.state{...}
./keccakfast.go:28:68:[1] init stmt: goto .i0
./keccakfast.go:28:68:[1] init stmt: .i0: 
./keccakfast.go:28:68:.i0:  non-looping label
./keccakfast.go:28:44:[1] init stmt: var ~r0 reflect.Value
./keccakfast.go:28:44:[1] init stmt: ~r0 = <nil>
./keccakfast.go:28:44:[1] init stmt: <node inlmark>
./keccakfast.go:28:44:[1] init stmt: if reflect.i == nil { ~r0 = reflect.Value{}; goto .i1 }
./keccakfast.go:28:44:[1] init stmt: ~r0 = reflect.Value{}; goto .i1
./keccakfast.go:28:44:[1] init stmt: ~r0 = reflect.Value{}
./keccakfast.go:28:44:[1] init stmt: goto .i1
./keccakfast.go:28:44:[1] init stmt: ~r0 = ~r0; goto .i1
./keccakfast.go:28:44:[1] init stmt: ~r0 = ~r0
./keccakfast.go:28:44:[1] init stmt: reflect.i := reflect.i
./keccakfast.go:28:44:[1] init stmt: var reflect.i any
./keccakfast.go:28:44:[1] init stmt: var ~r0 reflect.Value
./keccakfast.go:28:44:[1] init stmt: ~r0 = <nil>
./keccakfast.go:28:44:[1] init stmt: <node inlmark>
./keccakfast.go:28:44:[1] init stmt: reflect.e := (*abi.EmptyInterface)(unsafe.Pointer(&reflect.i))
./keccakfast.go:28:44:[1] init stmt: var reflect.e *abi.EmptyInterface
./keccakfast.go:28:44:[1] init stmt: reflect.t := reflect.e.Type
./keccakfast.go:28:44:[1] init stmt: var reflect.t *abi.Type
./keccakfast.go:28:44:[1] init stmt: if reflect.t == nil { ~r0 = reflect.Value{}; goto .i2 }
./keccakfast.go:28:44:[1] init stmt: ~r0 = reflect.Value{}; goto .i2
./keccakfast.go:28:44:[1] init stmt: ~r0 = reflect.Value{}
./keccakfast.go:28:44:[1] init stmt: goto .i2
./keccakfast.go:28:44:[1] init stmt: reflect.f := reflect.flag(~r0)
./keccakfast.go:28:44:[1] init stmt: var reflect.f reflect.flag
./keccakfast.go:28:44:[1] init stmt: abi.t := reflect.t
./keccakfast.go:28:44:[1] init stmt: var abi.t *abi.Type
./keccakfast.go:28:44:[1] init stmt: <node inlmark>
./keccakfast.go:28:44:[1] init stmt: var ~r0 abi.Kind; ~r0 = abi.t.Kind_ & abi.Kind(31); goto .i3
./keccakfast.go:28:44:[1] init stmt: var ~r0 abi.Kind
./keccakfast.go:28:44:[1] init stmt: ~r0 = abi.t.Kind_ & abi.Kind(31)
./keccakfast.go:28:44:[1] init stmt: goto .i3
./keccakfast.go:28:44:[1] init stmt: .i3: 
./keccakfast.go:28:44:.i3:  non-looping label
./keccakfast.go:28:44:[1] init stmt: if ~r0 { reflect.f |= reflect.flag(128) }
./keccakfast.go:28:44:[1] init stmt: abi.t := reflect.t
./keccakfast.go:28:44:[1] init stmt: var abi.t *abi.Type
./keccakfast.go:28:44:[1] init stmt: <node inlmark>
./keccakfast.go:28:44:[1] init stmt: var ~r0 bool; ~r0 = abi.t.Kind_ & abi.Kind(32) == abi.Kind(0); goto .i4
./keccakfast.go:28:44:[1] init stmt: var ~r0 bool
./keccakfast.go:28:44:[1] init stmt: ~r0 = abi.t.Kind_ & abi.Kind(32) == abi.Kind(0)
./keccakfast.go:28:44:[1] init stmt: goto .i4
./keccakfast.go:28:44:[1] init stmt: .i4: 
./keccakfast.go:28:44:.i4:  non-looping label
./keccakfast.go:28:44:[1] init stmt: reflect.f |= reflect.flag(128)
./keccakfast.go:28:44:[1] init stmt: ~r0 = reflect.Value{...}; goto .i2
./keccakfast.go:28:44:[1] init stmt: ~r0 = reflect.Value{...}
./keccakfast.go:28:44:[1] init stmt: goto .i2
./keccakfast.go:28:44:[1] init stmt: .i2: 
./keccakfast.go:28:44:.i2:  non-looping label
./keccakfast.go:28:44:[1] init stmt: goto .i1
./keccakfast.go:28:44:[1] init stmt: .i1: 
./keccakfast.go:28:44:.i1:  non-looping label
./keccakfast.go:28:68: &sha3.state{...} escapes to heap:
./keccakfast.go:28:68:   flow: ~r0 = &{storage for &sha3.state{...}}:
./keccakfast.go:28:68:     from &sha3.state{...} (spill) at ./keccakfast.go:28:68
./keccakfast.go:28:68:     from &sha3.state{...} (interface-converted) at ./keccakfast.go:28:68
./keccakfast.go:28:68:     from ~r0 = &sha3.state{...} (assign-pair) at ./keccakfast.go:28:68
./keccakfast.go:28:68:   flow: reflect.i = ~r0:
./keccakfast.go:28:68:     from ~r0 (interface-converted) at ./keccakfast.go:28:68
./keccakfast.go:28:68:     from reflect.i := ~r0 (assign-pair) at ./keccakfast.go:28:44
./keccakfast.go:28:68:   flow: reflect.i = reflect.i:
./keccakfast.go:28:68:     from reflect.i := reflect.i (assign-pair) at ./keccakfast.go:28:44
./keccakfast.go:28:68:   flow: reflect.e = &reflect.i:
./keccakfast.go:28:68:     from &reflect.i (address-of) at ./keccakfast.go:28:44
./keccakfast.go:28:68:     from reflect.e := (*abi.EmptyInterface)(unsafe.Pointer(&reflect.i)) (assign) at ./keccakfast.go:28:44
./keccakfast.go:28:68:   flow: ~r0 = *reflect.e:
./keccakfast.go:28:68:     from reflect.e.Data (dot of pointer) at ./keccakfast.go:28:44
./keccakfast.go:28:68:     from reflect.Value{...} (struct literal element) at ./keccakfast.go:28:44
./keccakfast.go:28:68:     from ~r0 = reflect.Value{...} (assign-pair) at ./keccakfast.go:28:44
./keccakfast.go:28:68:   flow: ~r0 = ~r0:
./keccakfast.go:28:68:     from ~r0 = ~r0 (assign-pair) at ./keccakfast.go:28:44
./keccakfast.go:28:68:   flow: {heap} = ~r0:
./keccakfast.go:28:68:     from reflect.Value.UnsafePointer(~r0) (call parameter) at ./keccakfast.go:28:85
./keccakfast.go:28:68:     from hasher = (*keccakState)(reflect.Value.UnsafePointer(~r0)) (assign) at ./keccakfast.go:28:5
./keccakfast.go:28:68: &sha3.state{...} escapes to heap
./keccakfast.go:39:13:[1] hash stmt: keccakReset(hasher)
./keccakfast.go:40:7:[1] hash stmt: _, _ = int(.autotmp_2), .autotmp_3
./keccakfast.go:40:7:[1] hash stmt: .autotmp_2, .autotmp_3 := keccakWrite(hasher, data[:])
./keccakfast.go:40:7:[1] hash stmt: var .autotmp_2 int
./keccakfast.go:40:7:[1] hash stmt: var .autotmp_3 error
./keccakfast.go:41:7:[1] hash stmt: _, _ = int(.autotmp_4), .autotmp_5
./keccakfast.go:41:7:[1] hash stmt: .autotmp_4, .autotmp_5 := keccakRead(hasher, out[:])
./keccakfast.go:41:7:[1] hash stmt: var .autotmp_4 int
./keccakfast.go:41:7:[1] hash stmt: var .autotmp_5 error
./keccakfast.go:42:2:[1] hash stmt: return 
```

Thought I'd share this little experiment and the results.
