### PR TITLE
chore: Clean up contract

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Install Golang
         uses: actions/setup-go@v5
         with:

--- a/rvgo/bindings/riscv.go
+++ b/rvgo/bindings/riscv.go
@@ -31,7 +31,7 @@ var (
 
 // RISCVMetaData contains all meta data concerning the RISCV contract.
 var RISCVMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_oracle\",\"type\":\"address\",\"internalType\":\"contractIPreimageOracle\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"oracle\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIPreimageOracle\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"step\",\"inputs\":[{\"name\":\"stateData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"localContext\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"nonpayable\"}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_oracle\",\"type\":\"address\",\"internalType\":\"contractIPreimageOracle\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"oracle\",\"inputs\":[],\"outputs\":[{\"name\":\"oracle_\",\"type\":\"address\",\"internalType\":\"contractIPreimageOracle\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"step\",\"inputs\":[{\"name\":\"_stateData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_localContext\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"version\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"}]",
 }
 
 // RISCVABI is the input ABI used to generate the binding from.
@@ -182,7 +182,7 @@ func (_RISCV *RISCVTransactorRaw) Transact(opts *bind.TransactOpts, method strin
 
 // Oracle is a free data retrieval call binding the contract method 0x7dc0d1d0.
 //
-// Solidity: function oracle() view returns(address)
+// Solidity: function oracle() view returns(address oracle_)
 func (_RISCV *RISCVCaller) Oracle(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
 	err := _RISCV.contract.Call(opts, &out, "oracle")
@@ -199,35 +199,66 @@ func (_RISCV *RISCVCaller) Oracle(opts *bind.CallOpts) (common.Address, error) {
 
 // Oracle is a free data retrieval call binding the contract method 0x7dc0d1d0.
 //
-// Solidity: function oracle() view returns(address)
+// Solidity: function oracle() view returns(address oracle_)
 func (_RISCV *RISCVSession) Oracle() (common.Address, error) {
 	return _RISCV.Contract.Oracle(&_RISCV.CallOpts)
 }
 
 // Oracle is a free data retrieval call binding the contract method 0x7dc0d1d0.
 //
-// Solidity: function oracle() view returns(address)
+// Solidity: function oracle() view returns(address oracle_)
 func (_RISCV *RISCVCallerSession) Oracle() (common.Address, error) {
 	return _RISCV.Contract.Oracle(&_RISCV.CallOpts)
 }
 
-// Step is a paid mutator transaction binding the contract method 0xe14ced32.
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
 //
-// Solidity: function step(bytes stateData, bytes proof, bytes32 localContext) returns(bytes32)
-func (_RISCV *RISCVTransactor) Step(opts *bind.TransactOpts, stateData []byte, proof []byte, localContext [32]byte) (*types.Transaction, error) {
-	return _RISCV.contract.Transact(opts, "step", stateData, proof, localContext)
+// Solidity: function version() view returns(string)
+func (_RISCV *RISCVCaller) Version(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _RISCV.contract.Call(opts, &out, "version")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_RISCV *RISCVSession) Version() (string, error) {
+	return _RISCV.Contract.Version(&_RISCV.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_RISCV *RISCVCallerSession) Version() (string, error) {
+	return _RISCV.Contract.Version(&_RISCV.CallOpts)
 }
 
 // Step is a paid mutator transaction binding the contract method 0xe14ced32.
 //
-// Solidity: function step(bytes stateData, bytes proof, bytes32 localContext) returns(bytes32)
-func (_RISCV *RISCVSession) Step(stateData []byte, proof []byte, localContext [32]byte) (*types.Transaction, error) {
-	return _RISCV.Contract.Step(&_RISCV.TransactOpts, stateData, proof, localContext)
+// Solidity: function step(bytes _stateData, bytes _proof, bytes32 _localContext) returns(bytes32)
+func (_RISCV *RISCVTransactor) Step(opts *bind.TransactOpts, _stateData []byte, _proof []byte, _localContext [32]byte) (*types.Transaction, error) {
+	return _RISCV.contract.Transact(opts, "step", _stateData, _proof, _localContext)
 }
 
 // Step is a paid mutator transaction binding the contract method 0xe14ced32.
 //
-// Solidity: function step(bytes stateData, bytes proof, bytes32 localContext) returns(bytes32)
-func (_RISCV *RISCVTransactorSession) Step(stateData []byte, proof []byte, localContext [32]byte) (*types.Transaction, error) {
-	return _RISCV.Contract.Step(&_RISCV.TransactOpts, stateData, proof, localContext)
+// Solidity: function step(bytes _stateData, bytes _proof, bytes32 _localContext) returns(bytes32)
+func (_RISCV *RISCVSession) Step(_stateData []byte, _proof []byte, _localContext [32]byte) (*types.Transaction, error) {
+	return _RISCV.Contract.Step(&_RISCV.TransactOpts, _stateData, _proof, _localContext)
+}
+
+// Step is a paid mutator transaction binding the contract method 0xe14ced32.
+//
+// Solidity: function step(bytes _stateData, bytes _proof, bytes32 _localContext) returns(bytes32)
+func (_RISCV *RISCVTransactorSession) Step(_stateData []byte, _proof []byte, _localContext [32]byte) (*types.Transaction, error) {
+	return _RISCV.Contract.Step(&_RISCV.TransactOpts, _stateData, _proof, _localContext)
 }

--- a/rvgo/bindings/riscv.go
+++ b/rvgo/bindings/riscv.go
@@ -31,7 +31,7 @@ var (
 
 // RISCVMetaData contains all meta data concerning the RISCV contract.
 var RISCVMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_oracle\",\"type\":\"address\",\"internalType\":\"contractIPreimageOracle\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"oracle\",\"inputs\":[],\"outputs\":[{\"name\":\"oracle_\",\"type\":\"address\",\"internalType\":\"contractIPreimageOracle\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"step\",\"inputs\":[{\"name\":\"_stateData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_localContext\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"version\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_oracle\",\"type\":\"address\",\"internalType\":\"contractIPreimageOracle\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"oracle\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIPreimageOracle\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"step\",\"inputs\":[{\"name\":\"_stateData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_localContext\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"version\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"}]",
 }
 
 // RISCVABI is the input ABI used to generate the binding from.
@@ -182,7 +182,7 @@ func (_RISCV *RISCVTransactorRaw) Transact(opts *bind.TransactOpts, method strin
 
 // Oracle is a free data retrieval call binding the contract method 0x7dc0d1d0.
 //
-// Solidity: function oracle() view returns(address oracle_)
+// Solidity: function oracle() view returns(address)
 func (_RISCV *RISCVCaller) Oracle(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
 	err := _RISCV.contract.Call(opts, &out, "oracle")
@@ -199,14 +199,14 @@ func (_RISCV *RISCVCaller) Oracle(opts *bind.CallOpts) (common.Address, error) {
 
 // Oracle is a free data retrieval call binding the contract method 0x7dc0d1d0.
 //
-// Solidity: function oracle() view returns(address oracle_)
+// Solidity: function oracle() view returns(address)
 func (_RISCV *RISCVSession) Oracle() (common.Address, error) {
 	return _RISCV.Contract.Oracle(&_RISCV.CallOpts)
 }
 
 // Oracle is a free data retrieval call binding the contract method 0x7dc0d1d0.
 //
-// Solidity: function oracle() view returns(address oracle_)
+// Solidity: function oracle() view returns(address)
 func (_RISCV *RISCVCallerSession) Oracle() (common.Address, error) {
 	return _RISCV.Contract.Oracle(&_RISCV.CallOpts)
 }

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1648,4 +1648,3 @@ contract RISCV is IBigStepper {
         }
     }
 }
-

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -11,7 +11,7 @@ import { IBigStepper } from "@optimism/src/dispute/interfaces/IBigStepper.sol";
 /// @dev https://github.com/ethereum-optimism/asterisc
 contract RISCV is IBigStepper {
     /// @notice The preimage oracle contract.
-    IPreimageOracle internal immutable ORACLE;
+    IPreimageOracle public oracle;
 
     /// @notice The version of the contract.
     /// @custom:semver 1.1.0-rc.1
@@ -19,13 +19,7 @@ contract RISCV is IBigStepper {
 
     /// @param _oracle The preimage oracle contract.
     constructor(IPreimageOracle _oracle) {
-        ORACLE = _oracle;
-    }
-
-    /// @notice Getter for the pre-image oracle contract.
-    /// @return oracle_ The pre-image oracle contract.
-    function oracle() external view returns (IPreimageOracle oracle_) {
-        oracle_ = ORACLE;
+        oracle = _oracle;
     }
 
     /// @inheritdoc IBigStepper


### PR DESCRIPTION
## Overview

Small changes to `RISCV.sol` for https://github.com/ethereum-optimism/optimism/pull/12994. Mainly syntax changes to pass semgrep and some doc comments.