### PR TITLE
Add 4-byte alignment check on pc in JAL/JALR instructions

### DIFF
--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -833,13 +833,23 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 		imm := parseImmTypeJ(instr)
 		rdValue := add64(pc, toU64(4))
 		setRegister(rd, rdValue)
-		setPC(add64(pc, signExtend64(shl64(toU64(1), imm), toU64(20)))) // signed offset in multiples of 2 bytes (last bit is there, but ignored)
+
+		newPC := add64(pc, signExtend64(shl64(toU64(1), imm), toU64(20)))
+		if newPC&3 != 0 { // quick target alignment check
+			revertWithCode(riscv.ErrNotAlignedAddr, fmt.Errorf("pc %d not aligned with 4 bytes", newPC))
+		}
+		setPC(newPC) // signed offset in multiples of 2 bytes (last bit is there, but ignored)
 	case 0x67: // 110_0111: JALR = Jump and link register
 		rs1Value := getRegister(rs1)
 		imm := parseImmTypeI(instr)
 		rdValue := add64(pc, toU64(4))
 		setRegister(rd, rdValue)
-		setPC(and64(add64(rs1Value, signExtend64(imm, toU64(11))), xor64(u64Mask(), toU64(1)))) // least significant bit is set to 0
+
+		newPC := and64(add64(rs1Value, signExtend64(imm, toU64(11))), xor64(u64Mask(), toU64(1)))
+		if newPC&3 != 0 { // quick addr alignment check
+			revertWithCode(riscv.ErrNotAlignedAddr, fmt.Errorf("pc %d not aligned with 4 bytes", newPC))
+		}
+		setPC(newPC) // least significant bit is set to 0
 	case 0x73: // 111_0011: environment things
 		switch funct3 {
 		case 0: // 000 = ECALL/EBREAK

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1496,7 +1496,13 @@ contract RISCV is IBigStepper {
                 let imm := parseImmTypeJ(instr)
                 let rdValue := add64(_pc, toU64(4))
                 setRegister(rd, rdValue)
-                setPC(add64(_pc, signExtend64(shl64(toU64(1), imm), toU64(20)))) // signed offset in multiples of 2
+
+                let newPC := add64(_pc, signExtend64(shl64(toU64(1), imm), toU64(20)))
+                if and64(newPC, toU64(3)) {
+                    // quick target alignment check
+                    revertWithCode(0xbad10ad0) // target not aligned with 4 bytes
+                }
+                setPC(newPC) // signed offset in multiples of 2
                     // bytes (last bit is there, but ignored)
             }
             case 0x67 {
@@ -1505,8 +1511,13 @@ contract RISCV is IBigStepper {
                 let imm := parseImmTypeI(instr)
                 let rdValue := add64(_pc, toU64(4))
                 setRegister(rd, rdValue)
-                setPC(and64(add64(rs1Value, signExtend64(imm, toU64(11))), xor64(u64Mask(), toU64(1)))) // least
-                    // significant bit is set to 0
+
+                let newPC := and64(add64(rs1Value, signExtend64(imm, toU64(11))), xor64(u64Mask(), toU64(1)))
+                if and64(newPC, toU64(3)) {
+                    // quick target alignment check
+                    revertWithCode(0xbad10ad0) // target not aligned with 4 bytes
+                }
+                setPC(newPC) // least significant bit is set to 0
             }
             case 0x73 {
                 // 111_0011: environment things

--- a/rvsol/test/RISCV.t.sol
+++ b/rvsol/test/RISCV.t.sol
@@ -2246,7 +2246,7 @@ contract RISCV_Test is CommonTest {
     /* J Type instructions */
 
     function test_jal_succeeds() public {
-        uint32 imm = 0xbef054ae;
+        uint32 imm = 0xbef054ac;
         uint32 insn = encodeJType(0x6f, 5, imm); // jal x5, imm
         (State memory state, bytes memory proof) = constructRISCVState(0, insn);
         bytes memory encodedState = encodeState(state);

--- a/rvsol/test/RISCV.t.sol
+++ b/rvsol/test/RISCV.t.sol
@@ -2460,6 +2460,17 @@ contract RISCV_Test is CommonTest {
         riscv.step(encodedState, proof, 0);
     }
 
+    function test_revert_unaligned_jal_instruction() public {
+        // 0xbef054ae % 4 != 0
+        uint32 imm = 0xbef054ae;
+        uint32 insn = encodeJType(0x6f, 5, imm); // jal x5, imm
+        (State memory state, bytes memory proof) = constructRISCVState(0, insn);
+        bytes memory encodedState = encodeState(state);
+
+        vm.expectRevert(hex"00000000000000000000000000000000000000000000000000000000bad10ad0");
+        riscv.step(encodedState, proof, 0);
+    }
+
     /* Helper methods */
 
     function encodeState(State memory state) internal pure returns (bytes memory) {


### PR DESCRIPTION
## Description

The [RISC-V specifications](https://riscv.org/specifications/ratified/) indicate the following in section "2.5.1. Unconditional Jumps".

> The JAL and JALR instructions **will generate an instruction-address-misaligned exception if the target
address is not aligned to a four-byte boundary**.

However, the three implementations (fast, slow, solidity) succeed when a unconditional jump instruction (JAL or JALR) sets a program counter `pc` not aligned on 4 bytes.

The jump opcodes (`0x67` and `0x6F`) implementation should raise an exception when the new program counter `pc` is not aligned on 4 bytes.