### PR TITLE
Hardcord state offset values to save gas and execution time

### DIFF
--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -285,34 +285,44 @@ contract RISCV is IBigStepper {
                 out := 0
             }
             function stateOffsetPreimageKey() -> out {
-                out := add(stateOffsetMemRoot(), stateSizeMemRoot())
+                out := 32 // 0 + 32
+                    //                out := add(stateOffsetMemRoot(), stateSizeMemRoot())
             }
             function stateOffsetPreimageOffset() -> out {
-                out := add(stateOffsetPreimageKey(), stateSizePreimageKey())
+                out := 64 // 32 + 32
+                    //                out := add(stateOffsetPreimageKey(), stateSizePreimageKey())
             }
             function stateOffsetPC() -> out {
-                out := add(stateOffsetPreimageOffset(), stateSizePreimageOffset())
+                out := 72 // 64 + 8
+                    //                out := add(stateOffsetPreimageOffset(), stateSizePreimageOffset())
             }
             function stateOffsetExitCode() -> out {
-                out := add(stateOffsetPC(), stateSizePC())
+                out := 80 // 72 + 8
+                    //                out := add(stateOffsetPC(), stateSizePC())
             }
             function stateOffsetExited() -> out {
-                out := add(stateOffsetExitCode(), stateSizeExitCode())
+                out := 81 // 80 + 1
+                    //                out := add(stateOffsetExitCode(), stateSizeExitCode())
             }
             function stateOffsetStep() -> out {
-                out := add(stateOffsetExited(), stateSizeExited())
+                out := 82 // 81 + 1
+                    //                out := add(stateOffsetExited(), stateSizeExited())
             }
             function stateOffsetHeap() -> out {
-                out := add(stateOffsetStep(), stateSizeStep())
+                out := 90 // 82 + 8
+                    //                out := add(stateOffsetStep(), stateSizeStep())
             }
             function stateOffsetLoadReservation() -> out {
-                out := add(stateOffsetHeap(), stateSizeHeap())
+                out := 98 // 90 + 8
+                    //                out := add(stateOffsetHeap(), stateSizeHeap())
             }
             function stateOffsetRegisters() -> out {
-                out := add(stateOffsetLoadReservation(), stateSizeLoadReservation())
+                out := 106 // 98 + 8
+                    //                out := add(stateOffsetLoadReservation(), stateSizeLoadReservation())
             }
             function stateSize() -> out {
-                out := add(stateOffsetRegisters(), stateSizeRegisters())
+                out := 362 // 106 + 256
+                    //                out := add(stateOffsetRegisters(), stateSizeRegisters())
             }
 
             //


### PR DESCRIPTION
## Description

Multiple functions are implemented to calculate the state offset of a given field. However, the offset of a field depends on the offset of the previous field until reaching the first offset. As a given offset depends on the previous offset, the code consumes a lot of gas for values that will never change.

For example, calling `stateOffsetPreimageKey` would consume approximately 444 gas while `stateSize` consume 1096 gas. Both will always return the same value.

Note that Go slow and fast implementations do not need this type of optimization as computations are cheaper.