### PR TITLE
Use only the lowest 32 bit of input for 32 bit division operations

### DIFF
--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -760,7 +760,7 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 		setPC(add64(pc, toU64(4)))
 	case 0x3B: // 011_1011: register arithmetic and logic in 32 bits
 		rs1Value := getRegister(rs1)
-		rs2Value := getRegister(rs2)
+		rs2Value := and64(getRegister(rs2), u32Mask())
 		var rdValue U64
 		switch funct7 {
 		case 1: // RV M extension

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -933,7 +933,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		setPC(add64(pc, toU64(4)))
 	case 0x3B: // 011_1011: register arithmetic and logic in 32 bits
 		rs1Value := getRegister(rs1)
-		rs2Value := getRegister(rs2)
+		rs2Value := and64(getRegister(rs2), u32Mask())
 		var rdValue U64
 		switch funct7.val() {
 		case 1: // RV M extension

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1399,7 +1399,7 @@ contract RISCV is IBigStepper {
             case 0x3B {
                 // 011_1011: register arithmetic and logic in 32 bits
                 let rs1Value := getRegister(rs1)
-                let rs2Value := getRegister(rs2)
+                let rs2Value := and64(getRegister(rs2), u32Mask())
                 let rdValue := 0
                 switch funct7
                 case 1 {


### PR DESCRIPTION
## Description

The RISCV implementations (sol/fast/slow) return incorrect results, in conflict with the RISCV specification, for all 32-bit division operations (DIVW, DIVUW, REMW, REMUW) when the divisor is zero.

All word (32-bit) arithmetic operations are supposed to take as its operands only the lowest 32 bits of the input registers.

However, in the division by zero code that requirement fails.

Observe that the switch statement only catches the case in which the input register **has all bits set to zero**. In reality, only the least significant 32 bits should be considered.

In the case any of the most significant 32 bits is set, the `switch` statement will follow the default path, and the division will be performed with the same behavior as an EVM division (except for sign extending) -- **that means the division by zero will result in a zero result, instead of the correct RISCV one** (all bits set for division, or the original numerator for remainder).

Mask the input before the switch statement.