### PR TITLE
Use modulo instead of and operation to validate the proof size

### DIFF
--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -129,7 +129,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 
 	proofContentOffset := shortToU64(uint16(stateContentOffset) + paddedStateSize + 32)
 
-	if and(b32asBEWord(calldataload(shortToU64(uint16(stateContentOffset)+paddedStateSize))), shortToU256(60-1)) != (U256{}) {
+	if mod(b32asBEWord(calldataload(shortToU64(uint16(stateContentOffset)+paddedStateSize))), toU256(60)) != toU256(0) {
 		// proof offset must be stateContentOffset+paddedStateSize+32
 		// proof size: 64-5+1=60 * 32 byte leaf,
 		// but multiple memProof can be used, so the proofSize must be a multiple of 60

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -129,7 +129,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 
 	proofContentOffset := shortToU64(uint16(stateContentOffset) + paddedStateSize + 32)
 
-	if mod(b32asBEWord(calldataload(shortToU64(uint16(stateContentOffset)+paddedStateSize))), toU256(60)) != toU256(0) {
+	if mod(b32asBEWord(calldataload(shortToU64(uint16(stateContentOffset)+paddedStateSize))), shortToU256(60*32)) != toU256(0) {
 		// proof offset must be stateContentOffset+paddedStateSize+32
 		// proof size: 64-5+1=60 * 32 byte leaf,
 		// but multiple memProof can be used, so the proofSize must be a multiple of 60


### PR DESCRIPTION
## Description

The slow implementation loads the `_proof` length from calldata and checks that this length is a multiple of 60.

However, this check uses a logical AND which may lead to accepting invalid values that are not multiple of 60.

```solidity
	if and(b32asBEWord(calldataload(shortToU64(uint16(stateContentOffset)+paddedStateSize))), shortToU256(60-1)) != (U256{}) {
```

Moreover, the check is insufficient. `_proof` is expected to be a multiple of `60 * 32`, however only the fact that it is a multiple of 60 is checked.

The logical AND check should be replaced with a modulo operation to ensure that it is a multiple of `32 * 60`.
