### PR TITLE
Add 4-byte alignment check on pc in branching instructions

### DIFF
--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -632,7 +632,8 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 			pc = add64(pc, imm)
 		}
 
-		if pc&3 != 0 { // quick target alignment check
+		// The PC must be aligned to 4 bytes.
+		if pc&3 != 0 {
 			revertWithCode(riscv.ErrNotAlignedAddr, fmt.Errorf("pc %d not aligned with 4 bytes", pc))
 		}
 

--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -631,6 +631,11 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 			// So it's really 13 bits with a hardcoded 0 bit.
 			pc = add64(pc, imm)
 		}
+
+		if pc&3 != 0 { // quick target alignment check
+			revertWithCode(riscv.ErrNotAlignedAddr, fmt.Errorf("pc %d not aligned with 4 bytes", pc))
+		}
+
 		// not like the other opcodes: nothing to write to rd register, and PC has already changed
 		setPC(pc)
 	case 0x13: // 001_0011: immediate arithmetic and logic

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -805,7 +805,8 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 			pc = add64(pc, imm)
 		}
 
-		if and64(pc, toU64(3)) != (U64{}) { // quick target alignment check
+		// The PC must be aligned to 4 bytes.
+		if and64(pc, toU64(3)) != (U64{}) {
 			revertWithCode(riscv.ErrNotAlignedAddr, fmt.Errorf("pc %d not aligned with 4 bytes", pc))
 		}
 

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -804,6 +804,11 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 			// So it's really 13 bits with a hardcoded 0 bit.
 			pc = add64(pc, imm)
 		}
+
+		if and64(pc, toU64(3)) != (U64{}) { // quick target alignment check
+			revertWithCode(riscv.ErrNotAlignedAddr, fmt.Errorf("pc %d not aligned with 4 bytes", pc))
+		}
+
 		// not like the other opcodes: nothing to write to rd register, and PC has already changed
 		setPC(pc)
 	case 0x13: // 001_0011: immediate arithmetic and logic

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1206,6 +1206,12 @@ contract RISCV is IBigStepper {
                     // So it's really 13 bits with a hardcoded 0 bit.
                     _pc := add64(_pc, imm)
                 }
+
+                if and64(_pc, toU64(3)) {
+                    // quick target alignment check
+                    revertWithCode(0xbad10ad0) // target not aligned with 4 bytes
+                }
+
                 // not like the other opcodes: nothing to write to rd register, and PC has already changed
                 setPC(_pc)
             }

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1207,10 +1207,8 @@ contract RISCV is IBigStepper {
                     _pc := add64(_pc, imm)
                 }
 
-                if and64(_pc, toU64(3)) {
-                    // quick target alignment check
-                    revertWithCode(0xbad10ad0) // target not aligned with 4 bytes
-                }
+                // The PC must be aligned to 4 bytes.
+                if and64(_pc, toU64(3)) { revertWithCode(0xbad10ad0) } // target not aligned with 4 bytes
 
                 // not like the other opcodes: nothing to write to rd register, and PC has already changed
                 setPC(_pc)

--- a/rvsol/test/RISCV.t.sol
+++ b/rvsol/test/RISCV.t.sol
@@ -2034,7 +2034,7 @@ contract RISCV_Test is CommonTest {
     function test_beq_succeeds() public {
         uint16 imm = 0x19cd;
         uint32 insn = encodeBType(0x63, 0, 23, 20, imm); // beq x23, x20, offset
-        (State memory state, bytes memory proof) = constructRISCVState(0x139a, insn);
+        (State memory state, bytes memory proof) = constructRISCVState(0x139c, insn);
         state.registers[23] = 0x2152;
         state.registers[20] = 0x2152;
         bytes memory encodedState = encodeState(state);
@@ -2060,7 +2060,7 @@ contract RISCV_Test is CommonTest {
     }
 
     function test_bne_succeeds() public {
-        uint16 imm = 0x1d7e;
+        uint16 imm = 0x1d7c;
         uint32 insn = encodeBType(0x63, 1, 20, 26, imm); // bne x20, x26, offset
         (State memory state, bytes memory proof) = constructRISCVState(0x1afc, insn);
         state.registers[20] = 0x14b6;
@@ -2144,9 +2144,9 @@ contract RISCV_Test is CommonTest {
     }
 
     function test_bltu_succeeds() public {
-        uint16 imm = 0x171d;
+        uint16 imm = 0x171c;
         uint32 insn = encodeBType(0x63, 6, 13, 22, imm); // bltu x13, x22, offset
-        (State memory state, bytes memory proof) = constructRISCVState(0x2e3a, insn);
+        (State memory state, bytes memory proof) = constructRISCVState(0x2e3c, insn);
         state.registers[13] = 0xa0cc;
         state.registers[22] = 0xffffffff_ffff795c;
         bytes memory encodedState = encodeState(state);
@@ -2174,7 +2174,7 @@ contract RISCV_Test is CommonTest {
     function test_bgeu_succeeds() public {
         uint16 imm = 0x14b5;
         uint32 insn = encodeBType(0x63, 7, 7, 16, imm); // bgeu x7, x16, offset
-        (State memory state, bytes memory proof) = constructRISCVState(0x296a, insn);
+        (State memory state, bytes memory proof) = constructRISCVState(0x296c, insn);
         state.registers[7] = 0xffffffff_ffff35e5;
         state.registers[16] = 0x7c3c;
         bytes memory encodedState = encodeState(state);


### PR DESCRIPTION
## Description

The [RISC-V specifications](https://riscv.org/specifications/ratified/) indicate the following in section "2.5.2. Conditional Branches".

> The conditional branch instructions **will generate an instruction-address-misaligned exception if the
target address is not aligned to a four-byte boundary and the branch condition evaluates to true**. If the
branch condition evaluates to false, the instruction-address-misaligned exception will not be raised.

However, the three implementations (fast, slow, solidity) succeed when a conditional branch instruction sets a program counter `pc` not aligned on 4 bytes.


The branching opcode (`0x63`) implementation should raise an exception when the new program counter `pc` is not aligned on 4 bytes.