### PR TITLE
Check size is not greater than 8 for RV32A and RV63A

### DIFF
--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -867,7 +867,7 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 		// 0b010 == RV32A W variants
 		// 0b011 == RV64A D variants
 		size := shl64(funct3, toU64(1))
-		if lt64(size, toU64(4)) != 0 {
+		if lt64(size, toU64(4)) != 0 || gt64(size, toU64(8)) != 0 {
 			revertWithCode(riscv.ErrBadAMOSize, fmt.Errorf("bad AMO size: %d", size))
 		}
 		addr := getRegister(rs1)

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -1040,7 +1040,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		// 0b010 == RV32A W variants
 		// 0b011 == RV64A D variants
 		size := shl64(funct3, toU64(1))
-		if lt64(size, toU64(4)) != (U64{}) {
+		if or64(lt64(size, toU64(4)), gt64(size, toU64(8))) != (U64{}) {
 			revertWithCode(riscv.ErrBadAMOSize, fmt.Errorf("bad AMO size: %d", size))
 		}
 		addr := getRegister(rs1)


### PR DESCRIPTION
## Description

The RV63A and RV32A operations are supported by the VM implementations.
The corresponding instructions encode the size in the `funct3` field.

The Solidity implementation ensures that the size is correct by checking that it is not lower than 4 and not greater than 8.

```solidity
        // 0b010 == RV32A W variants
        // 0b011 == RV64A D variants
        let size := shl64(funct3, toU64(1))
        if or(lt64(size, toU64(4)), gt64(size, toU64(8))) { revertWithCode(0xbada70) } // bad AMO size
```

However, the Go slow and fast implementations only check that the size is not lower than 4.
There is no check to ensure it is not greater than 8.

```go
	// 0b010 == RV32A W variants
	// 0b011 == RV64A D variants
	size := shl64(funct3, toU64(1))
	if lt64(size, toU64(4)) != 0 {
		revertWithCode(riscv.ErrBadAMOSize, fmt.Errorf("bad AMO size: %d", size))
	}
```

The Go implementations (slow and fast) should ensure that the size is not greater than 8.