### PR TITLE
Remove duplicative constants in state.go and fix mismatched page size

### DIFF
--- a/rvgo/fast/memory.go
+++ b/rvgo/fast/memory.go
@@ -140,7 +140,7 @@ func (m *Memory) GetUnaligned(addr uint64, dest []byte) {
 	p, ok := m.pageLookup(pageIndex)
 	var d int
 	if !ok {
-		l := pageSize - pageAddr
+		l := PageSize - pageAddr
 		if l > 32 {
 			l = 32
 		}
@@ -160,7 +160,7 @@ func (m *Memory) GetUnaligned(addr uint64, dest []byte) {
 	pageAddr = addr & PageAddrMask
 	p, ok = m.pageLookup(pageIndex)
 	if !ok {
-		l := pageSize - pageAddr
+		l := PageSize - pageAddr
 		if l > 32 {
 			l = 32
 		}

--- a/rvgo/fast/state.go
+++ b/rvgo/fast/state.go
@@ -13,16 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// page size must be at least 32 bytes (one merkle node)
-// memory merkleization will look the same regardless of page size past 32.
-const (
-	pageAddrSize = 10
-	pageKeySize  = 64 - pageAddrSize
-	pageSize     = 1 << pageAddrSize
-	pageAddrMask = pageSize - 1
-	maxPageCount = 1 << pageKeySize
-)
-
 type VMState struct {
 	Memory *Memory `json:"memory"`
 


### PR DESCRIPTION
There are two different constant definition in `state.go` and `memory.go` which are confusing and actually mis-used. This PR removes the constant definition in `state.go` and fix the call in `memory.go/GetUnaligned`. 