### PR TITLE
Add slow VM validation for calldata offset checks

### DIFF
--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -129,8 +129,13 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 	}
 
 	stateContentOffset := uint8(4 + 32 + 32 + 32 + 32)
-	if iszero(eq(b32asBEWord(calldataload(byteToU64(4+32*3))), shortToU256(stateSize))) {
-		// user-provided state size must match expected state size
+	if iszero(eq(add(b32asBEWord(calldataload(byteToU64(4))), shortToU256(32+4)), shortToU256(uint16(stateContentOffset)))) {
+		// _stateData.offset = _stateData.pointer + 32 + 4
+		// 32*4+4 = 132 expected state data offset
+		panic("invalid state offset input")
+	}
+
+	if iszero(eq(b32asBEWord(calldataload(byteToU64(4+32*3))), shortToU256(stateSize))) { // user-provided state size must match expected state size
 		panic("invalid state size input")
 	}
 
@@ -140,6 +145,11 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		// proof offset must be stateContentOffset+paddedStateSize+32
 		// proof size: 64-5+1=60 * 32 byte leaf,
 		// but multiple memProof can be used, so the proofSize must be a multiple of 60
+		panic("invalid proof size input")
+	}
+
+	if iszero(eq(add(b32asBEWord(calldataload(toU64(36))), shortToU256(32+4)), u64ToU256(proofContentOffset))) {
+		// _proof.offset = proofContentOffset = _proof.pointer + 32 + 4
 		panic("invalid proof offset input")
 	}
 

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -128,8 +128,8 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		panic("invalid function selector")
 	}
 
-	stateContentOffset := uint8(4 + 32 + 32 + 32 + 32)
-	if iszero(eq(add(b32asBEWord(calldataload(byteToU64(4))), shortToU256(32+4)), shortToU256(uint16(stateContentOffset)))) {
+	stateContentOffset := uint16(4 + 32 + 32 + 32 + 32)
+	if iszero(eq(add(b32asBEWord(calldataload(byteToU64(4))), shortToU256(32+4)), shortToU256(stateContentOffset))) {
 		// _stateData.offset = _stateData.pointer + 32 + 4
 		// 32*4+4 = 132 expected state data offset
 		panic("invalid state offset input")
@@ -139,16 +139,16 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		panic("invalid state size input")
 	}
 
-	proofContentOffset := shortToU64(uint16(stateContentOffset) + paddedStateSize + 32)
+	proofContentOffset := shortToU64(stateContentOffset + paddedStateSize + 32)
 
-	if mod(b32asBEWord(calldataload(shortToU64(uint16(stateContentOffset)+paddedStateSize))), shortToU256(60*32)) != byteToU256(0) {
+	if mod(b32asBEWord(calldataload(shortToU64(stateContentOffset+paddedStateSize))), shortToU256(60*32)) != byteToU256(0) {
 		// proof offset must be stateContentOffset+paddedStateSize+32
 		// proof size: 64-5+1=60 * 32 byte leaf,
 		// but multiple memProof can be used, so the proofSize must be a multiple of 60
 		panic("invalid proof size input")
 	}
 
-	if iszero(eq(add(b32asBEWord(calldataload(toU64(36))), shortToU256(32+4)), u64ToU256(proofContentOffset))) {
+	if iszero(eq(add(b32asBEWord(calldataload(byteToU64(36))), shortToU256(32+4)), u64ToU256(proofContentOffset))) {
 		// _proof.offset = proofContentOffset = _proof.pointer + 32 + 4
 		panic("invalid proof offset input")
 	}


### PR DESCRIPTION
## Description

The slow VM implementation is supposed to replicate the Solidity implementation. It takes as input the same `calldata` and process them.

However, the slow VM implementation lacks calldata offset checks for the `_stateData` and `_proof` parameters.
This can lead the same calldata payload to succeed on the slow implementation but revert on the Solidity implementation.

The Solidity implementation ensures that the `_stateData.offset == 132` and that `_proof.offset == 548`.

```solidity
            //
            // Initial EVM memory / calldata checks
            //
            if iszero(eq(mload(0x40), 0x80)) {
                // expected memory check: no allocated memory (start after scratch + free-mem-ptr + zero slot = 0x80)
                revert(0, 0)
            }
            if iszero(eq(_stateData.offset, 132)) { // @POC: check _stateData offset
                // 32*4+4 = 132 expected state data offset
                revert(0, 0)
            }
            if iszero(eq(calldataload(sub(_stateData.offset, 32)), stateSize())) {
                // user-provided state size must match expected state size
                revert(0, 0)
            }
            function paddedLen(v) -> out {
                // padded to multiple of 32 bytes
                let padding := mod(sub(32, mod(v, 32)), 32)
                out := add(v, padding)
            }
            if iszero(eq(_proof.offset, add(add(_stateData.offset, paddedLen(stateSize())), 32))) {
                // 132+stateSize+padding+32 = expected proof offset
                revert(0, 0)
            }
            function proofContentOffset() -> out {
                // since we can't reference proof.offset in functions, blame Yul
                // 132+362+(32-362%32)+32=548
                out := 548
            }
            if iszero(eq(_proof.offset, proofContentOffset())) { revert(0, 0) } // @POC: check _proof offset
```

But, Go slow implementation does not check those.

```go
	//
	// Initial EVM memory / calldata checks
	//
	calldataload := func(offset U64) (out [32]byte) {
		copy(out[:], calldata[offset.val():])
		return
	}

	stateContentOffset := uint8(4 + 32 + 32 + 32 + 32)
	if iszero(eq(b32asBEWord(calldataload(toU64(4+32*3))), shortToU256(stateSize))) {
		// user-provided state size must match expected state size
		panic("invalid state size input")
	}

	proofContentOffset := shortToU64(uint16(stateContentOffset) + paddedStateSize + 32)

	if and(b32asBEWord(calldataload(shortToU64(uint16(stateContentOffset)+paddedStateSize))), shortToU256(60-1)) != (U256{}) {
		// proof offset must be stateContentOffset+paddedStateSize+32
		// proof size: 64-5+1=60 * 32 byte leaf,
		// but multiple memProof can be used, so the proofSize must be a multiple of 60
		panic("invalid proof offset input")
	}
```

---

Thus, this implements the same offsets check in the Go slow implementation.