### PR TITLE
Add function selector check for slow vm

### DIFF
--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -1,6 +1,7 @@
 package slow
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -119,6 +120,12 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 	calldataload := func(offset U64) (out [32]byte) {
 		copy(out[:], calldata[offset.val():])
 		return
+	}
+
+	// First 4 bytes of keccak256("step(bytes,bytes,bytes32)")
+	expectedSelector := []byte{0xe1, 0x4c, 0xed, 0x32}
+	if len(calldata) < 4 || !bytes.Equal(calldata[:4], expectedSelector) {
+		panic("invalid function selector")
 	}
 
 	stateContentOffset := uint8(4 + 32 + 32 + 32 + 32)


### PR DESCRIPTION
## Description
The Go slow implementation is intended to mirror the Solidity implementation. For this, it takes the calldata as input.

However, the slow implementation lacks a check that is abstracted in the Solidity implementation: the function selector.

As the function selector is not checked, calldata with incorrect selector will be executable on the slow implementation but will revert on the Solidity smart contract.

Ensure on the slow implementation that the first 4 bytes of calldata correspond to the correct function selector.

