### PR TITLE
Revert load instructions with reserved bits[14:12] = 111

### DIFF
--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -587,6 +587,12 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 	switch opcode {
 	case 0x03: // 000_0011: memory loading
 		// LB, LH, LW, LD, LBU, LHU, LWU
+
+		// bits[14:12] set to 111 are reserved
+		if eq64(funct3, toU64(0x7)) != 0 {
+			revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+		}
+
 		imm := parseImmTypeI(instr)
 		signed := iszero64(and64(funct3, toU64(4)))      // 4 = 100 -> bitflag
 		size := shl64(and64(funct3, toU64(3)), toU64(1)) // 3 = 11 -> 1, 2, 4, 8 bytes size

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -760,6 +760,12 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 	switch opcode.val() {
 	case 0x03: // 000_0011: memory loading
 		// LB, LH, LW, LD, LBU, LHU, LWU
+
+		// bits[14:12] set to 111 are reserved
+		if eq64(funct3, toU64(0x7)) != (U64{}) {
+			revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+		}
+
 		imm := parseImmTypeI(instr)
 		signed := iszero64(and64(funct3, toU64(4)))      // 4 = 100 -> bitflag
 		size := shl64(and64(funct3, toU64(3)), toU64(1)) // 3 = 11 -> 1, 2, 4, 8 bytes size

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1147,6 +1147,10 @@ contract RISCV is IBigStepper {
                 let pc_ := _pc
                 // 000_0011: memory loading
                 // LB, LH, LW, LD, LBU, LHU, LWU
+
+                // bits[14:12] set to 111 are reserved
+                if eq64(funct3, toU64(0x7)) { revertWithCode(0xf001ca11) }
+
                 let imm := parseImmTypeI(instr)
                 let signed := iszero64(and64(funct3, toU64(4))) // 4 = 100 -> bitflag
                 let size := shl64(and64(funct3, toU64(3)), toU64(1)) // 3 = 11 -> 1, 2, 4, 8 bytes size

--- a/rvsol/test/RISCV.t.sol
+++ b/rvsol/test/RISCV.t.sol
@@ -2460,6 +2460,18 @@ contract RISCV_Test is CommonTest {
         riscv.step(encodedState, proof, 0);
     }
 
+    function test_reserved_load_instruction() public {
+        bytes32 value = hex"61fb11d66dcc9d48";
+        uint16 offset = 0x6bf;
+        uint64 addr = 0xd34d + offset;
+        uint32 insn = encodeIType(0x3, 21, 0x7, 4, offset); // lhu x21, funct 0x7, offset(x4)
+        (State memory state, bytes memory proof) = constructRISCVState(0, insn, addr, value);
+        state.registers[4] = 0xd34d;
+        bytes memory encodedState = encodeState(state);
+
+        vm.expectRevert(hex"00000000000000000000000000000000000000000000000000000000f001ca11");
+        riscv.step(encodedState, proof, 0);
+    }
     /* Helper methods */
 
     function encodeState(State memory state) internal pure returns (bytes memory) {


### PR DESCRIPTION
The [RISC-V specifications](https://riscv.org/specifications/ratified/) indicate the following in section "1.5.1 Expanded Instruction-Length Encoding".

The encoding with bits [14:12] set to "111" is reserved for future longer instruction encodings.

Moreover, it states the following about reserved instructions.

> Reserved encodings are currently not defined but are saved for future standard extensions; once thus used, they become standard encodings.

> The behavior upon decoding a reserved instruction is UNSPECIFIED.

> Some platforms may require that opcodes reserved for standard use raise an illegalinstruction exception. Other platforms may permit reserved opcode space be used for nonconforming extensions

However, the RISCV implementations (solidity, slow, fast) support the reserved LOAD instruction that has bits [14:12] set to "111" and will have the same behaviour than "011". The same applies for "100", "101 and "110". This reserved instruction should not be supported.


Raise an illegal-instruction exception instead of executing this reserved instruction for which behavior is unspecified.