### PR TITLE
fix: broken link riscv.md

### DIFF
--- a/docs/riscv.md
+++ b/docs/riscv.md
@@ -3,7 +3,7 @@
 ## Helpful learning resources
 
 - rv32 instruction set cheat sheet: http://blog.translusion.com/images/posts/RISC-V-cheatsheet-RV32I-4-3.pdf
-- rv32: reference card: https://github.com/jameslzhu/riscv-card/blob/master/riscv-card.pdf
+- rv32: reference card: https://github.com/jameslzhu/riscv-card/releases/download/latest/riscv-card.pdf
 - online riscv32 interpreter: https://www.cs.cornell.edu/courses/cs3410/2019sp/riscv/interpreter/#
 - specs: https://riscv.org/technical/specifications/
 - Berkely riscv card: https://inst.eecs.berkeley.edu/~cs61c/fa18/img/riscvcard.pdf


### PR DESCRIPTION
Hi!
Updated the broken link for the RV32 reference card to the correct release URL:
https://github.com/jameslzhu/riscv-card/releases/download/latest/riscv-card.pdf

This change aligns with the update made in [commit 6628be3](https://github.com/jameslzhu/riscv-card/commit/6628be3cca53b590896ae7a72a9d9446eee7bfd1).

