### PR TITLE
Fix != 0 check in rvsol

### DIFF
--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -888,7 +888,7 @@ contract RISCV is IBigStepper {
 
                     let errCode := 0
                     // ensure MAP_ANONYMOUS is set and fd == -1
-                    switch or(iszero(and(flags, 0x20)), eq(eq(fd, u64Mask()), 0))
+                    switch or(iszero(and(flags, 0x20)), iszero(eq(fd, u64Mask())))
                     case 1 {
                         addr := u64Mask()
                         errCode := toU64(0x4d)

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -888,7 +888,7 @@ contract RISCV is IBigStepper {
 
                     let errCode := 0
                     // ensure MAP_ANONYMOUS is set and fd == -1
-                    switch or(iszero(and(flags, 0x20)), not(eq(fd, u64Mask())))
+                    switch or(iszero(and(flags, 0x20)), eq(eq(fd, u64Mask()), 0))
                     case 1 {
                         addr := u64Mask()
                         errCode := toU64(0x4d)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Using bitwise not on a 0 padded uint256 value results in the value being uint256.max when it should be 1. 

Use eq(x,0) to check for not instead. 
