### PR TITLE
Check lastPreimage != nil before accessing the cached preimage

### DIFF
--- a/rvgo/fast/instrumented.go
+++ b/rvgo/fast/instrumented.go
@@ -73,7 +73,7 @@ func (m *InstrumentedState) Step(proof bool) (wit *StepWitness, err error) {
 
 func (m *InstrumentedState) readPreimage(key [32]byte, offset uint64) (dat [32]byte, datLen uint64, err error) {
 	preimage := m.lastPreimage
-	if key != m.lastPreimageKey {
+	if preimage == nil || key != m.lastPreimageKey {
 		m.lastPreimageKey = key
 		data := m.preimageOracle.GetPreimage(key)
 		// add the length prefix

--- a/rvgo/fast/instrumented_test.go
+++ b/rvgo/fast/instrumented_test.go
@@ -1,0 +1,43 @@
+package fast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type MockPreimageOracle struct {
+}
+
+func (oracle *MockPreimageOracle) Hint(v []byte) {
+}
+
+func (oracle *MockPreimageOracle) GetPreimage(k [32]byte) []byte {
+	return make([]byte, 32)
+}
+
+func (oracle *MockPreimageOracle) ReadPreimagePart(key [32]byte, offset uint64) ([32]byte, uint8, error) {
+	return [32]byte{}, 32, nil
+}
+
+func TestReadPreimage(t *testing.T) {
+
+	vmState := VMState{
+		PC:        0,
+		Memory:    NewMemory(),
+		Registers: [32]uint64{},
+		ExitCode:  0,
+		Exited:    false,
+		Heap:      0x7f_00_00_00_00_00,
+	}
+
+	// instruction ecall
+	vmState.Memory.SetUnaligned(0, []byte{0x73})
+	vmState.Registers[17] = 63
+	vmState.Registers[10] = 5
+
+	instState := NewInstrumentedState(&vmState, &MockPreimageOracle{}, nil, nil)
+
+	_, err := instState.Step(true)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The Fast VM implementation assumes the last preimage read has been cached, even if this is the first read. Moreover, the preimage key is always initialized to zeroes ([32]byte{}) while the cached preimage value is initialized to a null pointer.

That means if either there's an attempt to read the preimage value before writing a key, or if the key written is zero, an attempt to access the null pointer will cause a panic.

Neither scenario should happen in a correct Kona implementation -- reads should always be preceded by writing the corresponding key, and a key with zero value isn't valid. However this is the oracle's concern and should be delegated to it.

