### PR TITLE
Correctly write over the page boundary in SetUnaligned

### DIFF
--- a/rvgo/fast/memory.go
+++ b/rvgo/fast/memory.go
@@ -128,7 +128,7 @@ func (m *Memory) SetUnaligned(addr uint64, dat []byte) {
 		m.Invalidate(addr) // invalidate this branch of memory, now that the value changed
 	}
 
-	copy(p.Data[pageAddr:], dat)
+	copy(p.Data[pageAddr:], dat[d:])
 }
 
 func (m *Memory) GetUnaligned(addr uint64, dest []byte) {

--- a/rvgo/fast/memory_test.go
+++ b/rvgo/fast/memory_test.go
@@ -412,3 +412,12 @@ func TestMemoryBinary(t *testing.T) {
 	m.GetUnaligned(8, dest[:])
 	require.Equal(t, uint8(123), dest[0])
 }
+
+func TestMemoryInvalidSetUnaligned(t *testing.T) {
+	t.Run("SetUnaligned incorrectly writes to next page", func(t *testing.T) {
+		m := NewMemory()
+		m.SetUnaligned(0x0FFE, []byte{0xaa, 0xbb, 0xcc, 0xdd})
+		require.Equal(t, m.pages[0].Data[4094:], []byte{0xaa, 0xbb})
+		require.Equal(t, m.pages[1].Data[0:2], []byte{0xcc, 0xdd})
+	})
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The Memory.SetUnaligned function writes data at a given address. When the data doesn't fit into the given page, the remaining data is expected to be written on the next page.

However, the implementation is incorrect. During the copy on the second page, the whole data will be written instead of the remaining data.


This PR fixes it so that the remaining data over the page boundary is written to the next page correctly