### PR TITLE
Revert instructions where encoding is unrecognized

### DIFF
--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -666,11 +666,15 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 				rdValue = shr64(and64(imm, byteToU64(0x3F)), rs1Value) // lower 6 bits in 64 bit mode
 			case 0x10: // 010000 = SRAI
 				rdValue = sar64(and64(imm, byteToU64(0x3F)), rs1Value) // lower 6 bits in 64 bit mode
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid imm value %d for opcode 0x13", imm))
 			}
 		case 6: // 110 = ORI
 			rdValue = or64(rs1Value, imm)
 		case 7: // 111 = ANDI
 			rdValue = and64(rs1Value, imm)
+		default:
+			revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x13", funct3))
 		}
 		setRegister(rd, rdValue)
 		setPC(add64(pc, byteToU64(4)))
@@ -698,7 +702,11 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 				rdValue = signExtend64(shr64(shamt, and64(rs1Value, u32Mask())), byteToU64(31))
 			case 0x20: // 0100000 = SRAIW
 				rdValue = signExtend64(shr64(shamt, and64(rs1Value, u32Mask())), sub64(byteToU64(31), shamt))
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid imm value %d for opcode 0x1B", imm))
 			}
+		default:
+			revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x1B", funct3))
 		}
 		setRegister(rd, rdValue)
 		setPC(add64(pc, byteToU64(4)))
@@ -745,6 +753,8 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 				default:
 					rdValue = mod64(rs1Value, rs2Value)
 				}
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x33", funct3))
 			}
 		default:
 			switch funct3 {
@@ -754,6 +764,8 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 					rdValue = add64(rs1Value, rs2Value)
 				case 0x20: // 0100000 = SUB
 					rdValue = sub64(rs1Value, rs2Value)
+				default:
+					revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct7 value %d for funct3 %d", funct7, funct3))
 				}
 			case 1: // 001 = SLL
 				rdValue = shl64(and64(rs2Value, byteToU64(0x3F)), rs1Value) // only the low 6 bits are consider in RV6VI
@@ -769,11 +781,15 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 					rdValue = shr64(and64(rs2Value, byteToU64(0x3F)), rs1Value) // logical: fill with zeroes
 				case 0x20: // 0100000 = SRA
 					rdValue = sar64(and64(rs2Value, byteToU64(0x3F)), rs1Value) // arithmetic: sign bit is extended
+				default:
+					revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct7 value %d for funct3 %d", funct7, funct3))
 				}
 			case 6: // 110 = OR
 				rdValue = or64(rs1Value, rs2Value)
 			case 7: // 111 = AND
 				rdValue = and64(rs1Value, rs2Value)
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x3B", funct3))
 			}
 		}
 		setRegister(rd, rdValue)
@@ -815,6 +831,8 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 				default:
 					rdValue = mask32Signed64(mod64(and64(rs1Value, u32Mask()), and64(rs2Value, u32Mask())))
 				}
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x3B", funct3))
 			}
 		default:
 			switch funct3 {
@@ -824,6 +842,8 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 					rdValue = mask32Signed64(add64(and64(rs1Value, u32Mask()), and64(rs2Value, u32Mask())))
 				case 0x20: // 0100000 = SUBW
 					rdValue = mask32Signed64(sub64(and64(rs1Value, u32Mask()), and64(rs2Value, u32Mask())))
+				default:
+					revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct7 value %d for funct3 %d", funct7, funct3))
 				}
 			case 1: // 001 = SLLW
 				rdValue = mask32Signed64(shl64(and64(rs2Value, byteToU64(0x1F)), rs1Value))
@@ -834,7 +854,11 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 					rdValue = signExtend64(shr64(shamt, and64(rs1Value, u32Mask())), byteToU64(31))
 				case 0x20: // 0100000 = SRAW
 					rdValue = signExtend64(shr64(shamt, and64(rs1Value, u32Mask())), sub64(byteToU64(31), shamt))
+				default:
+					revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct7 value %d for funct3 %d", funct7, funct3))
 				}
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x3B", funct3))
 			}
 		}
 		setRegister(rd, rdValue)

--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -590,7 +590,7 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 
 		// bits[14:12] set to 111 are reserved
 		if eq64(funct3, byteToU64(0x7)) != 0 {
-			revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+			revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 		}
 
 		imm := parseImmTypeI(instr)
@@ -688,13 +688,13 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 		case 1: // 001 = SLLIW
 			// SLLIW where imm[5] != 0 is reserved
 			if and64(imm, byteToU64(0x20)) != 0 {
-				revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 			}
 			rdValue = mask32Signed64(shl64(and64(imm, byteToU64(0x1F)), rs1Value))
 		case 5: // 101 = SR~
 			// SRLIW and SRAIW where imm[5] != 0 is reserved
 			if and64(imm, byteToU64(0x20)) != 0 {
-				revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 			}
 			shamt := and64(imm, byteToU64(0x1F))
 			switch shr64(byteToU64(5), imm) { // top 7 bits select the shift type

--- a/rvgo/riscv/constants.go
+++ b/rvgo/riscv/constants.go
@@ -51,6 +51,7 @@ const (
 	ErrUnexpectedRProofLoad           = uint64(0xbad22220)
 	ErrUnexpectedRProofStoreUnaligned = uint64(0xbad22221)
 	ErrUnexpectedRProofStore          = uint64(0xbad2222f)
+	ErrIllegalInstruction             = uint64(0xbadc0de)
 	ErrBadAMOSize                     = uint64(0xbada70)
 	ErrFailToReadPreimage             = uint64(0xbadf00d0)
 	ErrBadMemoryProof                 = uint64(0xbadf00d1)

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -774,7 +774,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 
 		// bits[14:12] set to 111 are reserved
 		if eq64(funct3, byteToU64(0x7)) != (U64{}) {
-			revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+			revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 		}
 
 		imm := parseImmTypeI(instr)
@@ -872,13 +872,13 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		case 1: // 001 = SLLIW
 			// SLLIW where imm[5] != 0 is reserved
 			if and64(imm, byteToU64(0x20)) != (U64{}) {
-				revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 			}
 			rdValue = mask32Signed64(shl64(and64(imm, byteToU64(0x1F)), rs1Value))
 		case 5: // 101 = SR~
 			// SRLIW and SRAIW imm[5] != 0 is reserved
 			if and64(imm, byteToU64(0x20)) != (U64{}) {
-				revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 			}
 			shamt := and64(imm, byteToU64(0x1F))
 			switch shr64(byteToU64(5), imm).val() { // top 7 bits select the shift type

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -850,11 +850,15 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 				rdValue = shr64(and64(imm, byteToU64(0x3F)), rs1Value) // lower 6 bits in 64 bit mode
 			case 0x10: // 010000 = SRAI
 				rdValue = sar64(and64(imm, byteToU64(0x3F)), rs1Value) // lower 6 bits in 64 bit mode
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid imm value %d for opcode 0x13", imm.val()))
 			}
 		case 6: // 110 = ORI
 			rdValue = or64(rs1Value, imm)
 		case 7: // 111 = ANDI
 			rdValue = and64(rs1Value, imm)
+		default:
+			revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x13", funct3.val()))
 		}
 		setRegister(rd, rdValue)
 		setPC(add64(pc, byteToU64(4)))
@@ -882,7 +886,11 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 				rdValue = signExtend64(shr64(shamt, and64(rs1Value, u32Mask())), byteToU64(31))
 			case 0x20: // 0100000 = SRAIW
 				rdValue = signExtend64(shr64(shamt, and64(rs1Value, u32Mask())), sub64(byteToU64(31), shamt))
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid imm value %d for opcode 0x1B", imm.val()))
 			}
+		default:
+			revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x1B", funct3.val()))
 		}
 		setRegister(rd, rdValue)
 		setPC(add64(pc, byteToU64(4)))
@@ -929,6 +937,8 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 				default:
 					rdValue = mod64(rs1Value, rs2Value)
 				}
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x33", funct3.val()))
 			}
 		default:
 			switch funct3.val() {
@@ -938,6 +948,8 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 					rdValue = add64(rs1Value, rs2Value)
 				case 0x20: // 0100000 = SUB
 					rdValue = sub64(rs1Value, rs2Value)
+				default:
+					revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct7 value %d for funct3 %d", funct7.val(), funct3.val()))
 				}
 			case 1: // 001 = SLL
 				rdValue = shl64(and64(rs2Value, byteToU64(0x3F)), rs1Value) // only the low 6 bits are consider in RV6VI
@@ -953,11 +965,15 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 					rdValue = shr64(and64(rs2Value, byteToU64(0x3F)), rs1Value) // logical: fill with zeroes
 				case 0x20: // 0100000 = SRA
 					rdValue = sar64(and64(rs2Value, byteToU64(0x3F)), rs1Value) // arithmetic: sign bit is extended
+				default:
+					revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct7 value %d for funct3 %d", funct7.val(), funct3.val()))
 				}
 			case 6: // 110 = OR
 				rdValue = or64(rs1Value, rs2Value)
 			case 7: // 111 = AND
 				rdValue = and64(rs1Value, rs2Value)
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x3B", funct3.val()))
 			}
 		}
 		setRegister(rd, rdValue)
@@ -999,6 +1015,8 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 				default:
 					rdValue = mask32Signed64(mod64(and64(rs1Value, u32Mask()), and64(rs2Value, u32Mask())))
 				}
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x3B", funct3.val()))
 			}
 		default:
 			switch funct3.val() {
@@ -1008,6 +1026,8 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 					rdValue = mask32Signed64(add64(and64(rs1Value, u32Mask()), and64(rs2Value, u32Mask())))
 				case 0x20: // 0100000 = SUBW
 					rdValue = mask32Signed64(sub64(and64(rs1Value, u32Mask()), and64(rs2Value, u32Mask())))
+				default:
+					revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct7 value %d for funct3 %d", funct7.val(), funct3.val()))
 				}
 			case 1: // 001 = SLLW
 				rdValue = mask32Signed64(shl64(and64(rs2Value, byteToU64(0x1F)), rs1Value))
@@ -1018,7 +1038,11 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 					rdValue = signExtend64(shr64(shamt, and64(rs1Value, u32Mask())), byteToU64(31))
 				case 0x20: // 0100000 = SRAW
 					rdValue = signExtend64(shr64(shamt, and64(rs1Value, u32Mask())), sub64(byteToU64(31), shamt))
+				default:
+					revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct7 value %d for funct3 %d", funct7.val(), funct3.val()))
 				}
+			default:
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction: invalid funct3 value %d for opcode 0x3B", funct3.val()))
 			}
 		}
 		setRegister(rd, rdValue)

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1161,7 +1161,7 @@ contract RISCV is IBigStepper {
                 // LB, LH, LW, LD, LBU, LHU, LWU
 
                 // bits[14:12] set to 111 are reserved
-                if eq64(funct3, toU64(0x7)) { revertWithCode(0xf001ca11) }
+                if eq64(funct3, toU64(0x7)) { revertWithCode(0xbadc0de) }
 
                 let imm := parseImmTypeI(instr)
                 let signed := iszero64(and64(funct3, toU64(4))) // 4 = 100 -> bitflag
@@ -1295,12 +1295,12 @@ contract RISCV is IBigStepper {
                     // 001 = SLLIW
 
                     // SLLIW where imm[5] != 0 is reserved
-                    if and64(imm, toU64(0x20)) { revertWithCode(0xf001ca11) }
+                    if and64(imm, toU64(0x20)) { revertWithCode(0xbadc0de) }
                     rdValue := mask32Signed64(shl64(and64(imm, toU64(0x1F)), rs1Value))
                 }
                 case 5 {
                     // SRLIW and SRAIW where imm[5] != 0 is reserved
-                    if and64(imm, toU64(0x20)) { revertWithCode(0xf001ca11) }
+                    if and64(imm, toU64(0x20)) { revertWithCode(0xbadc0de) }
 
                     // 101 = SR~
                     let shamt := and64(imm, toU64(0x1F))

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1267,6 +1267,7 @@ contract RISCV is IBigStepper {
                         // 010000 = SRAI
                         rdValue := sar64(and64(imm, toU64(0x3F)), rs1Value) // lower 6 bits in 64 bit mode
                     }
+                    default { revertWithCode(0xbadc0de) }
                 }
                 case 6 {
                     // 110 = ORI
@@ -1276,6 +1277,7 @@ contract RISCV is IBigStepper {
                     // 111 = ANDI
                     rdValue := and64(rs1Value, imm)
                 }
+                default { revertWithCode(0xbadc0de) }
                 setRegister(rd, rdValue)
                 setPC(add64(_pc, toU64(4)))
             }
@@ -1312,7 +1314,9 @@ contract RISCV is IBigStepper {
                         // 0100000 = SRAIW
                         rdValue := signExtend64(shr64(shamt, and64(rs1Value, u32Mask())), sub64(toU64(31), shamt))
                     }
+                    default { revertWithCode(0xbadc0de) }
                 }
+                default { revertWithCode(0xbadc0de) }
                 setRegister(rd, rdValue)
                 setPC(add64(_pc, toU64(4)))
             }
@@ -1366,6 +1370,7 @@ contract RISCV is IBigStepper {
                         case 0 { rdValue := rs1Value }
                         default { rdValue := mod64(rs1Value, rs2Value) }
                     }
+                    default { revertWithCode(0xbadc0de) }
                 }
                 default {
                     switch funct3
@@ -1380,6 +1385,7 @@ contract RISCV is IBigStepper {
                             // 0100000 = SUB
                             rdValue := sub64(rs1Value, rs2Value)
                         }
+                        default { revertWithCode(0xbadc0de) }
                     }
                     case 1 {
                         // 001 = SLL
@@ -1409,6 +1415,7 @@ contract RISCV is IBigStepper {
                             // 0100000 = SRA
                             rdValue := sar64(and64(rs2Value, toU64(0x3F)), rs1Value) // arithmetic: sign bit is extended
                         }
+                        default { revertWithCode(0xbadc0de) }
                     }
                     case 6 {
                         // 110 = OR
@@ -1418,6 +1425,7 @@ contract RISCV is IBigStepper {
                         // 111 = AND
                         rdValue := and64(rs1Value, rs2Value)
                     }
+                    default { revertWithCode(0xbadc0de) }
                 }
                 setRegister(rd, rdValue)
                 setPC(add64(_pc, toU64(4)))
@@ -1467,6 +1475,7 @@ contract RISCV is IBigStepper {
                             rdValue := mask32Signed64(mod64(and64(rs1Value, u32Mask()), and64(rs2Value, u32Mask())))
                         }
                     }
+                    default { revertWithCode(0xbadc0de) }
                 }
                 default {
                     switch funct3
@@ -1481,6 +1490,7 @@ contract RISCV is IBigStepper {
                             // 0100000 = SUBW
                             rdValue := mask32Signed64(sub64(and64(rs1Value, u32Mask()), and64(rs2Value, u32Mask())))
                         }
+                        default { revertWithCode(0xbadc0de) }
                     }
                     case 1 {
                         // 001 = SLLW
@@ -1498,7 +1508,9 @@ contract RISCV is IBigStepper {
                             // 0100000 = SRAW
                             rdValue := signExtend64(shr64(shamt, and64(rs1Value, u32Mask())), sub64(toU64(31), shamt))
                         }
+                        default { revertWithCode(0xbadc0de) }
                     }
+                    default { revertWithCode(0xbadc0de) }
                 }
                 setRegister(rd, rdValue)
                 setPC(add64(_pc, toU64(4)))

--- a/rvsol/test/RISCV.t.sol
+++ b/rvsol/test/RISCV.t.sol
@@ -2487,7 +2487,7 @@ contract RISCV_Test is CommonTest {
         state.registers[25] = 0xf956;
         bytes memory encodedState = encodeState(state);
 
-        vm.expectRevert(hex"00000000000000000000000000000000000000000000000000000000f001ca11");
+        vm.expectRevert(hex"000000000000000000000000000000000000000000000000000000000badc0de");
         riscv.step(encodedState, proof, 0);
     }
 
@@ -2501,7 +2501,7 @@ contract RISCV_Test is CommonTest {
 
         bytes memory encodedState = encodeState(state);
 
-        vm.expectRevert(hex"00000000000000000000000000000000000000000000000000000000f001ca11");
+        vm.expectRevert(hex"000000000000000000000000000000000000000000000000000000000badc0de");
         riscv.step(encodedState, proof, 0);
     }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

In multiple opcodes handling, the behaviour of the virtual machine is unexpected when the instruction is not entirely recognized.

This type of unexpected behaviour is found in opcodes:
- 0x13, especially SR~ instructions
- 0x1B, especially SR~ instructions and when funct3 is not one of [0, 1, 5].
- 0x33, especially SR~ and ADD/SUB instructions
- 0x3B
  - when funct7 == 1 and funct3 is not one of [0, 4, 5, 6, 7]
  - when funct7 != 1 and instruction is SR~, ADDW/SUBW or not recognized.

This PR adds revert behavior to such unrecognized instruction encoding in rvgoand rvsol implementation. 
