### PR TITLE
Modify rvgo/fast/yul64.go implementation to use yul256 implementation like slow / evm

### DIFF
--- a/rvgo/fast/yul256.go
+++ b/rvgo/fast/yul256.go
@@ -17,7 +17,6 @@ func beWordAsB32(v U256) [32]byte {
 	return v.Bytes32()
 }
 
-// nolint:unused
 func add(x, y U256) (out U256) {
 	out.Add(&x, &y)
 	return
@@ -33,25 +32,21 @@ func mul(x, y U256) (out U256) {
 	return
 }
 
-// nolint:unused
 func div(x, y U256) (out U256) {
 	out.Div(&x, &y)
 	return
 }
 
-// nolint:unused
 func sdiv(x, y U256) (out U256) { // note: signed overflow semantics are the same between Go and EVM assembly
 	out.SDiv(&x, &y)
 	return
 }
 
-// nolint:unused
 func mod(x, y U256) (out U256) {
 	out.Mod(&x, &y)
 	return
 }
 
-// nolint:unused
 func smod(x, y U256) (out U256) {
 	out.SMod(&x, &y)
 	return
@@ -62,7 +57,6 @@ func not(x U256) (out U256) {
 	return
 }
 
-// nolint:unused
 func lt(x, y U256) (out U256) {
 	if x.Lt(&y) {
 		out.SetUint64(1)
@@ -70,7 +64,6 @@ func lt(x, y U256) (out U256) {
 	return
 }
 
-// nolint:unused
 func gt(x, y U256) (out U256) {
 	if x.Gt(&y) {
 		out.SetUint64(1)
@@ -78,7 +71,6 @@ func gt(x, y U256) (out U256) {
 	return
 }
 
-// nolint:unused
 func slt(x, y U256) (out U256) {
 	if x.Slt(&y) {
 		out.SetUint64(1)
@@ -86,7 +78,6 @@ func slt(x, y U256) (out U256) {
 	return
 }
 
-// nolint:unused
 func sgt(x, y U256) (out U256) {
 	if x.Sgt(&y) {
 		out.SetUint64(1)
@@ -94,7 +85,6 @@ func sgt(x, y U256) (out U256) {
 	return
 }
 
-// nolint:unused
 func eq(x, y U256) (out U256) {
 	if x.Eq(&y) {
 		out.SetUint64(1)
@@ -102,7 +92,6 @@ func eq(x, y U256) (out U256) {
 	return
 }
 
-// nolint:unused
 func iszero(x U256) bool {
 	return x.IsZero()
 }
@@ -117,13 +106,11 @@ func or(x, y U256) (out U256) {
 	return
 }
 
-// nolint:unused
 func xor(x, y U256) (out U256) {
 	out.Xor(&x, &y)
 	return
 }
 
-// returns y << x
 func shl(x, y U256) (out U256) {
 	if !x.IsUint64() && x.Uint64() >= 256 {
 		return
@@ -142,7 +129,6 @@ func shr(x, y U256) (out U256) {
 }
 
 // returns y >> x (signed)
-// nolint:unused
 func sar(x, y U256) (out U256) {
 	if !x.IsUint64() && x.Uint64() >= 256 {
 		return

--- a/rvgo/fast/yul64.go
+++ b/rvgo/fast/yul64.go
@@ -20,7 +20,6 @@ func shortToU256(v uint16) U256 {
 	return *uint256.NewInt(uint64(v))
 }
 
-// nolint:unused
 func longToU256(v uint64) U256 {
 	return *uint256.NewInt(v)
 }
@@ -66,118 +65,81 @@ func signExtend64To256(v U64) U256 {
 }
 
 func add64(x, y uint64) uint64 {
-	return x + y
+	return u256ToU64(add(longToU256(x), longToU256(y)))
 }
 
 func sub64(x, y uint64) uint64 {
-	return x - y
+	return u256ToU64(sub(longToU256(x), longToU256(y)))
 }
 
 func mul64(x, y uint64) uint64 {
-	return x * y
+	return u256ToU64(mul(longToU256(x), longToU256(y)))
 }
 
 func div64(x, y uint64) uint64 {
-	if y == 0 {
-		return 0
-	}
-	return x / y
+	return u256ToU64(div(longToU256(x), longToU256(y)))
 }
 
 func sdiv64(x, y uint64) uint64 { // note: signed overflow semantics are the same between Go and EVM assembly
-	if y == 0 {
-		return 0
-	}
-	if x == uint64(1<<63) && y == ^uint64(0) {
-		return 1 << 63
-	}
-	return uint64(int64(x) / int64(y))
+	return u256ToU64(sdiv(signExtend64To256(x), signExtend64To256(y)))
 }
 
 func mod64(x, y uint64) uint64 {
-	if y == 0 {
-		return 0
-	} else {
-		return x % y
-	}
+	return u256ToU64(mod(longToU256(x), longToU256(y)))
 }
 
 func smod64(x, y uint64) uint64 {
-	if y == 0 {
-		return 0
-	} else {
-		return uint64(int64(x) % int64(y))
-	}
+	return u256ToU64(smod(signExtend64To256(x), signExtend64To256(y)))
 }
 
 func not64(x uint64) uint64 {
-	return ^x
+	return u256ToU64(not(longToU256(x)))
 }
 
 func lt64(x, y uint64) uint64 {
-	if x < y {
-		return 1
-	} else {
-		return 0
-	}
+	return u256ToU64(lt(longToU256(x), longToU256(y)))
 }
 
 func gt64(x, y uint64) uint64 {
-	if x > y {
-		return 1
-	} else {
-		return 0
-	}
+	return u256ToU64(gt(longToU256(x), longToU256(y)))
 }
 
 func slt64(x, y uint64) uint64 {
-	if int64(x) < int64(y) {
-		return 1
-	} else {
-		return 0
-	}
+	return u256ToU64(slt(signExtend64To256(x), signExtend64To256(y)))
 }
 
 func sgt64(x, y uint64) uint64 {
-	if int64(x) > int64(y) {
-		return 1
-	} else {
-		return 0
-	}
+	return u256ToU64(sgt(signExtend64To256(x), signExtend64To256(y)))
 }
 
 func eq64(x, y uint64) uint64 {
-	if x == y {
-		return 1
-	} else {
-		return 0
-	}
+	return u256ToU64(eq(longToU256(x), longToU256(y)))
 }
 
 func iszero64(x uint64) bool {
-	return x == 0
+	return iszero(longToU256(x))
 }
 
-func and64(x, y uint64) uint64 {
-	return x & y
+func and64(x, y uint64) U64 {
+	return u256ToU64(and(longToU256(x), longToU256(y)))
 }
 
 func or64(x, y uint64) uint64 {
-	return x | y
+	return u256ToU64(or(longToU256(x), longToU256(y)))
 }
 
 func xor64(x, y uint64) uint64 {
-	return x ^ y
+	return u256ToU64(xor(longToU256(x), longToU256(y)))
 }
 
 func shl64(x, y uint64) uint64 {
-	return y << x
+	return u256ToU64(shl(longToU256(x), longToU256(y)))
 }
 
 func shr64(x, y uint64) uint64 {
-	return y >> x
+	return u256ToU64(shr(longToU256(x), longToU256(y)))
 }
 
 func sar64(x, y uint64) uint64 {
-	return uint64(int64(y) >> x)
+	return u256ToU64(sar(longToU256(x), signExtend64To256(y)))
 }


### PR DESCRIPTION
Currently, a series of calculation functions on yul256.go - specifically add, div, sdiv, mod, smod, lt, gt, slt, sgt, eq, iszero, xor, sar are unused

However, these functions are meant to be used in the yul64.go, as slow and evm implementation has yul64 calculation functions inherited from the behavior from yul256 functions. 