### PR TITLE
chore: Use mise for dependency management [1/N]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@ The interface of the Asterisc binary is essentially the same as Cannon for op-ch
 
 Read the [docs](./docs) to get started.
 
+### Development environment
+
+We use [`mise`](https://mise.jdx.dev/) as a dependency manager for these tools.
+Once properly installed, `mise` will provide the correct versions for each tool. `mise` does not
+replace any other installations of these binaries and will only serve these binaries when you are
+working inside of the `optimism` directory.
+
+#### Install `mise`
+
+Install `mise` by following the instructions provided on the
+[Getting Started page](https://mise.jdx.dev/getting-started.html#_1-install-mise-cli).
+
+#### Install dependencies
+
+```sh
+mise install
+```
+
+### Submodule dependencies
+
 Install the dependencies by running the following: 
 ```bash
 git submodule update --remote --init

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read the [docs](./docs) to get started.
 We use [`mise`](https://mise.jdx.dev/) as a dependency manager for these tools.
 Once properly installed, `mise` will provide the correct versions for each tool. `mise` does not
 replace any other installations of these binaries and will only serve these binaries when you are
-working inside of the `optimism` directory.
+working inside of the `asterisc` directory.
 
 #### Install `mise`
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,31 @@
+[tools]
+
+# Core dependencies
+go = "1.22.7"
+jq = "1.7.1"
+just = "1.37.0"
+
+# Code coverage
+"ubi:codecov/codecov-cli" = "v10.0.1"
+
+# Go dependencies
+"ubi:golangci/golangci-lint" = "v1.63.4"
+"go:github.com/ethereum/go-ethereum/cmd/geth" = "1.14.7"
+"go:gotest.tools/gotestsum" = "1.12.0"
+
+# Foundry dependencies
+# Foundry is a special case because it supplies multiple binaries at the same
+# GitHub release, so we need to use the aliasing trick to get mise to not error
+forge = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
+cast = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
+anvil = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
+
+# Foundry provides multiple binaries so we alias them here
+[alias]
+forge = "ubi:foundry-rs/foundry[exe=forge]"
+cast = "ubi:foundry-rs/foundry[exe=cast]"
+anvil = "ubi:foundry-rs/foundry[exe=anvil]"
+
+[settings]
+# Required for the go: dependencies
+experimental = true


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Before moving on to the migration Github Actions to CircleCI, I added `mise` as a dependency manager. `mise` is being used in the [`optimism` monorepo](https://github.com/ethereum-optimism/optimism/blob/develop/mise.toml), [supersim](https://github.com/ethereum-optimism/supersim) and others and provides a great way of managing tooling required for development.

It is an add-on, it does not break or affect any existing development flows, just provides a convenient way of setting up your development environment (as well as the CI environment).