### PR TITLE
Update exitcode from invalidSyscall to illegalInstruction

### DIFF
--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -590,7 +590,7 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 
 		// bits[14:12] set to 111 are reserved
 		if eq64(funct3, byteToU64(0x7)) != 0 {
-			revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+			revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 		}
 
 		imm := parseImmTypeI(instr)

--- a/rvgo/fast/vm.go
+++ b/rvgo/fast/vm.go
@@ -688,13 +688,13 @@ func (inst *InstrumentedState) riscvStep() (outErr error) {
 		case 1: // 001 = SLLIW
 			// SLLIW where imm[5] != 0 is reserved
 			if and64(imm, byteToU64(0x20)) != 0 {
-				revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 			}
 			rdValue = mask32Signed64(shl64(and64(imm, byteToU64(0x1F)), rs1Value))
 		case 5: // 101 = SR~
 			// SRLIW and SRAIW where imm[5] != 0 is reserved
 			if and64(imm, byteToU64(0x20)) != 0 {
-				revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 			}
 			shamt := and64(imm, byteToU64(0x1F))
 			switch shr64(byteToU64(5), imm) { // top 7 bits select the shift type

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -872,13 +872,13 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 		case 1: // 001 = SLLIW
 			// SLLIW where imm[5] != 0 is reserved
 			if and64(imm, byteToU64(0x20)) != (U64{}) {
-				revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 			}
 			rdValue = mask32Signed64(shl64(and64(imm, byteToU64(0x1F)), rs1Value))
 		case 5: // 101 = SR~
 			// SRLIW and SRAIW imm[5] != 0 is reserved
 			if and64(imm, byteToU64(0x20)) != (U64{}) {
-				revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+				revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 			}
 			shamt := and64(imm, byteToU64(0x1F))
 			switch shr64(byteToU64(5), imm).val() { // top 7 bits select the shift type

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -774,7 +774,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 
 		// bits[14:12] set to 111 are reserved
 		if eq64(funct3, byteToU64(0x7)) != (U64{}) {
-			revertWithCode(riscv.ErrInvalidSyscall, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
+			revertWithCode(riscv.ErrIllegalInstruction, fmt.Errorf("illegal instruction %d: reserved instruction encoding", instr))
 		}
 
 		imm := parseImmTypeI(instr)

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1161,7 +1161,7 @@ contract RISCV is IBigStepper {
                 // LB, LH, LW, LD, LBU, LHU, LWU
 
                 // bits[14:12] set to 111 are reserved
-                if eq64(funct3, toU64(0x7)) { revertWithCode(0xf001ca11) }
+                if eq64(funct3, toU64(0x7)) { revertWithCode(0xbadc0de) }
 
                 let imm := parseImmTypeI(instr)
                 let signed := iszero64(and64(funct3, toU64(4))) // 4 = 100 -> bitflag

--- a/rvsol/src/RISCV.sol
+++ b/rvsol/src/RISCV.sol
@@ -1295,12 +1295,12 @@ contract RISCV is IBigStepper {
                     // 001 = SLLIW
 
                     // SLLIW where imm[5] != 0 is reserved
-                    if and64(imm, toU64(0x20)) { revertWithCode(0xf001ca11) }
+                    if and64(imm, toU64(0x20)) { revertWithCode(0xbadc0de) }
                     rdValue := mask32Signed64(shl64(and64(imm, toU64(0x1F)), rs1Value))
                 }
                 case 5 {
                     // SRLIW and SRAIW where imm[5] != 0 is reserved
-                    if and64(imm, toU64(0x20)) { revertWithCode(0xf001ca11) }
+                    if and64(imm, toU64(0x20)) { revertWithCode(0xbadc0de) }
 
                     // 101 = SR~
                     let shamt := and64(imm, toU64(0x1F))

--- a/rvsol/test/RISCV.t.sol
+++ b/rvsol/test/RISCV.t.sol
@@ -2487,7 +2487,7 @@ contract RISCV_Test is CommonTest {
         state.registers[25] = 0xf956;
         bytes memory encodedState = encodeState(state);
 
-        vm.expectRevert(hex"00000000000000000000000000000000000000000000000000000000f001ca11");
+        vm.expectRevert(hex"000000000000000000000000000000000000000000000000000000000badc0de");
         riscv.step(encodedState, proof, 0);
     }
 
@@ -2501,7 +2501,7 @@ contract RISCV_Test is CommonTest {
 
         bytes memory encodedState = encodeState(state);
 
-        vm.expectRevert(hex"00000000000000000000000000000000000000000000000000000000f001ca11");
+        vm.expectRevert(hex"000000000000000000000000000000000000000000000000000000000badc0de");
         riscv.step(encodedState, proof, 0);
     }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Change the revert code for reserved/invalid instruction encoding from InvalidSyscall to IllegalInstruction. 