### PR TITLE
Add tests for checking vm proof sizes is multiple of 60*32

### DIFF
--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -136,7 +136,7 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 
 	proofContentOffset := shortToU64(uint16(stateContentOffset) + paddedStateSize + 32)
 
-	if mod(b32asBEWord(calldataload(shortToU64(uint16(stateContentOffset)+paddedStateSize))), shortToU256(60*32)) != toU256(0) {
+	if mod(b32asBEWord(calldataload(shortToU64(uint16(stateContentOffset)+paddedStateSize))), shortToU256(60*32)) != byteToU256(0) {
 		// proof offset must be stateContentOffset+paddedStateSize+32
 		// proof size: 64-5+1=60 * 32 byte leaf,
 		// but multiple memProof can be used, so the proofSize must be a multiple of 60

--- a/rvgo/test/evm_test.go
+++ b/rvgo/test/evm_test.go
@@ -150,6 +150,12 @@ func stepEVM(t *testing.T, env *vm.EVM, wit *fast.StepWitness, addrs *Addresses,
 		require.Equal(t, ret, revertCode)
 		return
 	}
+
+	if err != nil && ret == nil {
+		require.ErrorIs(t, err, vm.ErrExecutionReverted)
+		return
+	}
+
 	require.NoError(t, err, "evm must not fail (ret: %x), at step %d", ret, step)
 	gasUsed = startingGas - leftOverGas
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Add tests to validate the VM proof sizes are correct which are added in https://github.com/ethereum-optimism/asterisc/pull/101 and https://github.com/ethereum-optimism/asterisc/pull/99
This test checks to see if the vm reverts when the proof size is not a multiple of 60*32. 