### PR TITLE
chore: Clean up pipeline sequence [4/N]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,9 @@ workflows:
   main:
     jobs:
       - contracts-bedrock-build
-      - go-mod-download-monorepo
-      - go-mod-download-asterisc
-      - op-program-riscv:
-          requires:
-            - go-mod-download-monorepo
+      - op-program-riscv
       - asterisc-prestate:
           requires:
-            - go-mod-download-asterisc
             - op-program-riscv
             - contracts-bedrock-build
       - devnet-allocs-including-asterisc:
@@ -153,33 +148,6 @@ jobs:
             - "packages/contracts-bedrock/deploy-config/devnetL1.json"
             - "packages/contracts-bedrock/deployments/devnetL1"
             - ".devnet-standard"
-
-  go-mod-download-monorepo:
-    executor: default
-    steps:
-      - checkout-with-monorepo
-      - install-dependencies
-      - install-go-modules:
-          from: rvsol/lib/optimism/go.sum
-          after_download:
-            - run:
-                name: Tidy modules
-                command: make mod-tidy && git diff --exit-code
-                working_directory: rvsol/lib/optimism
-      - run:
-          name: run Go linter
-          command: |
-            # Identify how many cores it defaults to
-            golangci-lint run --help | grep concurrency
-            make lint-go
-          working_directory: rvsol/lib/optimism
-
-  go-mod-download-asterisc:
-    executor: default
-    steps:
-      - checkout
-      - install-dependencies
-      - install-go-modules
 
   op-program-riscv:
     executor: default


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- `go-mod-download-monorepo` job was, despite its name, lining `optimism` monorepo so it was dropped
- `go-mod-download-asterisc` job was just downloading the `go` modules so it was dropped

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
