### PR TITLE
chore: Migrate rvsol-tests workflow to CircleCI [6/N]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ workflows:
           version: "1.3.1"
           asterisc-commit: "25feabf"
       - rvgo-tests
+      - rvsol-tests
 
 commands:
   install-dependencies:
@@ -394,3 +395,18 @@ jobs:
       - run:
           name: Upload coverage to Codecov
           command: codecov-cli do-upload --token $CODECOV_TOKEN --verbose
+
+  rvsol-tests:
+    executor: default
+    steps:
+      - checkout
+      - install-dependencies
+      - install-go-modules
+      - run:
+          name: Build FFI
+          command: go build
+          working_directory: rvgo/scripts/go-ffi
+      - run:
+          name: Run foundry tests
+          command: forge test -vvv --ffi
+          working_directory: rvsol


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The title says it all.