### PR TITLE
chore: Increase resources for E2E tests CircleCI workflow [7/N]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,7 @@ jobs:
 
   devnet-allocs-including-asterisc:
     executor: default
+    resource_class: xlarge
     steps:
       - checkout-with-monorepo
       - install-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,7 @@ jobs:
 
   asterisc-prestate:
     executor: default
+    resource_class: xlarge
     steps:
       - checkout
       - install-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,7 @@ jobs:
 
   op-program-riscv:
     executor: default
+    resource_class: xlarge
     steps:
       - checkout-with-monorepo
       - install-dependencies


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The E2E job sequence is the one that takes the longest and some of the jobs were not being executed on the large runners.