### PR TITLE
chore: Migrate rvgo-lint workflow to CircleCI [9/N]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ workflows:
       - prestate-reproducibility:
           version: "1.3.1"
           asterisc-commit: "25feabf"
+      - rvgo-lint
       - rvgo-tests
       - rvsol-lint
       - rvsol-tests
@@ -375,6 +376,16 @@ jobs:
               echo "Prestate did not match expected"
               exit 1
             fi
+
+  rvgo-lint:
+    executor: default
+    steps:
+      - checkout
+      - install-dependencies
+      - install-go-modules
+      - run:
+          name: Run lint
+          command: golangci-lint run
 
   rvgo-tests:
     executor: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ workflows:
       - prestate-reproducibility:
           version: "1.3.1"
           asterisc-commit: "25feabf"
-      - rvgo-lint
+      - go-lint
       - rvgo-tests
       - rvsol-lint
       - rvsol-tests
@@ -377,7 +377,7 @@ jobs:
               exit 1
             fi
 
-  rvgo-lint:
+  go-lint:
     executor: default
     steps:
       - checkout


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The title says it all