### PR TITLE
chore: Migrate check-optimism-version-match workflow to CircleCI [12/N]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ executors:
 workflows:
   main:
     jobs:
+      - check-optimism-version-match
       - contracts-bedrock-build
       - op-program-riscv
       - op-program-test
@@ -106,6 +107,15 @@ commands:
           working_directory: rvsol/lib/optimism/packages/contracts-bedrock
 
 jobs:
+  check-optimism-version-match:
+    executor: default
+    steps:
+      - checkout-with-monorepo
+      - install-dependencies
+      - run:
+          name: Check if optimism submodule version matches go.mod version
+          command: ./.github/scripts/check_versions.sh
+          
   contracts-bedrock-build:
     executor: default
     resource_class: xlarge


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The title says it all