### PR TITLE
chore: Revert #131

### DIFF
--- a/rvgo/fast/yul256.go
+++ b/rvgo/fast/yul256.go
@@ -17,6 +17,7 @@ func beWordAsB32(v U256) [32]byte {
 	return v.Bytes32()
 }
 
+// nolint:unused
 func add(x, y U256) (out U256) {
 	out.Add(&x, &y)
 	return
@@ -32,21 +33,25 @@ func mul(x, y U256) (out U256) {
 	return
 }
 
+// nolint:unused
 func div(x, y U256) (out U256) {
 	out.Div(&x, &y)
 	return
 }
 
+// nolint:unused
 func sdiv(x, y U256) (out U256) { // note: signed overflow semantics are the same between Go and EVM assembly
 	out.SDiv(&x, &y)
 	return
 }
 
+// nolint:unused
 func mod(x, y U256) (out U256) {
 	out.Mod(&x, &y)
 	return
 }
 
+// nolint:unused
 func smod(x, y U256) (out U256) {
 	out.SMod(&x, &y)
 	return
@@ -57,6 +62,7 @@ func not(x U256) (out U256) {
 	return
 }
 
+// nolint:unused
 func lt(x, y U256) (out U256) {
 	if x.Lt(&y) {
 		out.SetUint64(1)
@@ -64,6 +70,7 @@ func lt(x, y U256) (out U256) {
 	return
 }
 
+// nolint:unused
 func gt(x, y U256) (out U256) {
 	if x.Gt(&y) {
 		out.SetUint64(1)
@@ -71,6 +78,7 @@ func gt(x, y U256) (out U256) {
 	return
 }
 
+// nolint:unused
 func slt(x, y U256) (out U256) {
 	if x.Slt(&y) {
 		out.SetUint64(1)
@@ -78,6 +86,7 @@ func slt(x, y U256) (out U256) {
 	return
 }
 
+// nolint:unused
 func sgt(x, y U256) (out U256) {
 	if x.Sgt(&y) {
 		out.SetUint64(1)
@@ -85,6 +94,7 @@ func sgt(x, y U256) (out U256) {
 	return
 }
 
+// nolint:unused
 func eq(x, y U256) (out U256) {
 	if x.Eq(&y) {
 		out.SetUint64(1)
@@ -92,6 +102,7 @@ func eq(x, y U256) (out U256) {
 	return
 }
 
+// nolint:unused
 func iszero(x U256) bool {
 	return x.IsZero()
 }
@@ -106,11 +117,13 @@ func or(x, y U256) (out U256) {
 	return
 }
 
+// nolint:unused
 func xor(x, y U256) (out U256) {
 	out.Xor(&x, &y)
 	return
 }
 
+// returns y << x
 func shl(x, y U256) (out U256) {
 	if !x.IsUint64() && x.Uint64() >= 256 {
 		return
@@ -129,6 +142,7 @@ func shr(x, y U256) (out U256) {
 }
 
 // returns y >> x (signed)
+// nolint:unused
 func sar(x, y U256) (out U256) {
 	if !x.IsUint64() && x.Uint64() >= 256 {
 		return

--- a/rvgo/fast/yul64.go
+++ b/rvgo/fast/yul64.go
@@ -20,6 +20,7 @@ func shortToU256(v uint16) U256 {
 	return *uint256.NewInt(uint64(v))
 }
 
+// nolint:unused
 func longToU256(v uint64) U256 {
 	return *uint256.NewInt(v)
 }
@@ -65,81 +66,118 @@ func signExtend64To256(v U64) U256 {
 }
 
 func add64(x, y uint64) uint64 {
-	return u256ToU64(add(longToU256(x), longToU256(y)))
+	return x + y
 }
 
 func sub64(x, y uint64) uint64 {
-	return u256ToU64(sub(longToU256(x), longToU256(y)))
+	return x - y
 }
 
 func mul64(x, y uint64) uint64 {
-	return u256ToU64(mul(longToU256(x), longToU256(y)))
+	return x * y
 }
 
 func div64(x, y uint64) uint64 {
-	return u256ToU64(div(longToU256(x), longToU256(y)))
+	if y == 0 {
+		return 0
+	}
+	return x / y
 }
 
 func sdiv64(x, y uint64) uint64 { // note: signed overflow semantics are the same between Go and EVM assembly
-	return u256ToU64(sdiv(signExtend64To256(x), signExtend64To256(y)))
+	if y == 0 {
+		return 0
+	}
+	if x == uint64(1<<63) && y == ^uint64(0) {
+		return 1 << 63
+	}
+	return uint64(int64(x) / int64(y))
 }
 
 func mod64(x, y uint64) uint64 {
-	return u256ToU64(mod(longToU256(x), longToU256(y)))
+	if y == 0 {
+		return 0
+	} else {
+		return x % y
+	}
 }
 
 func smod64(x, y uint64) uint64 {
-	return u256ToU64(smod(signExtend64To256(x), signExtend64To256(y)))
+	if y == 0 {
+		return 0
+	} else {
+		return uint64(int64(x) % int64(y))
+	}
 }
 
 func not64(x uint64) uint64 {
-	return u256ToU64(not(longToU256(x)))
+	return ^x
 }
 
 func lt64(x, y uint64) uint64 {
-	return u256ToU64(lt(longToU256(x), longToU256(y)))
+	if x < y {
+		return 1
+	} else {
+		return 0
+	}
 }
 
 func gt64(x, y uint64) uint64 {
-	return u256ToU64(gt(longToU256(x), longToU256(y)))
+	if x > y {
+		return 1
+	} else {
+		return 0
+	}
 }
 
 func slt64(x, y uint64) uint64 {
-	return u256ToU64(slt(signExtend64To256(x), signExtend64To256(y)))
+	if int64(x) < int64(y) {
+		return 1
+	} else {
+		return 0
+	}
 }
 
 func sgt64(x, y uint64) uint64 {
-	return u256ToU64(sgt(signExtend64To256(x), signExtend64To256(y)))
+	if int64(x) > int64(y) {
+		return 1
+	} else {
+		return 0
+	}
 }
 
 func eq64(x, y uint64) uint64 {
-	return u256ToU64(eq(longToU256(x), longToU256(y)))
+	if x == y {
+		return 1
+	} else {
+		return 0
+	}
 }
 
 func iszero64(x uint64) bool {
-	return iszero(longToU256(x))
+	return x == 0
 }
 
-func and64(x, y uint64) U64 {
-	return u256ToU64(and(longToU256(x), longToU256(y)))
+func and64(x, y uint64) uint64 {
+	return x & y
 }
 
 func or64(x, y uint64) uint64 {
-	return u256ToU64(or(longToU256(x), longToU256(y)))
+	return x | y
 }
 
 func xor64(x, y uint64) uint64 {
-	return u256ToU64(xor(longToU256(x), longToU256(y)))
+	return x ^ y
 }
 
 func shl64(x, y uint64) uint64 {
-	return u256ToU64(shl(longToU256(x), longToU256(y)))
+	return y << x
 }
 
 func shr64(x, y uint64) uint64 {
-	return u256ToU64(shr(longToU256(x), longToU256(y)))
+	return y >> x
 }
 
 func sar64(x, y uint64) uint64 {
-	return u256ToU64(sar(longToU256(x), signExtend64To256(y)))
+	return uint64(int64(y) >> x)
 }


### PR DESCRIPTION
## Overview

Reverts #131, which made use of the very slow `U256` arithmetic in the fast VM. The slow VM uses these types to be closer to Solidity, but the fast VM should be taking advantage of the native `uint64` arithmetic.

With the changes in #131, native emulation went from ~`1.8MHz` -> `0.3MHz` on my machine.