### PR TITLE
feat: add support for Asterisc prestate from OP stack deploy config

### DIFF
--- a/rvsol/scripts/Deploy.s.sol
+++ b/rvsol/scripts/Deploy.s.sol
@@ -92,8 +92,10 @@ contract Deploy is Deployer {
                 vm.toString(Claim.unwrap(riscvAbsolutePrestate_))
             );
         } else {
-            revert("Currently Asterisc only supports local devnet");
-            // TODO: Add Asterisc absolute prestate into OP stack deploy config
+            console.log(
+                "[Asterisc Dispute Game] Using absolute prestate from config: %x", cfg.faultGameAbsolutePrestate()
+            );
+            riscvAbsolutePrestate_ = Claim.wrap(bytes32(cfg.faultGameAbsolutePrestate()));
         }
     }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Implements the TODO in Deploy.s.sol by adding support for loading Asterisc absolute prestate from OP stack deploy configuration. Previously, the loadRiscvAbsolutePrestate() function would revert for non-devnet chains. Now it reads faultGameAbsolutePrestate from the deploy config, enabling Asterisc fault proof deployments on production networks.

Changes:
- Replace revert() with cfg.faultGameAbsolutePrestate() call for production networks
- Add proper logging to track prestate source
- Make implementation consistent with Deploy_Stage_1_4.sol

**Tests**

The implementation follows the exact same pattern as Deploy_Stage_1_4.sol which is already deployed and working on op-sepolia and op-mainnet networks. The cfg.faultGameAbsolutePrestate() method is well-tested in the existing codebase and deploy configs are already in place for production networks.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Resolves TODO comment in rvsol/scripts/Deploy.s.sol:89
