### PR TITLE
Update config documentation link in foundry.toml

### DIFF
--- a/rvsol/foundry.toml
+++ b/rvsol/foundry.toml
@@ -43,4 +43,4 @@ multiline_func_header='all'
 bracket_spacing=true
 wrap_comments=true
 
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md


### PR DESCRIPTION
Replaced the outdated or broken documentation link in the foundry.toml file with the official and up-to-date link to the Foundry config README on GitHub. This ensures users have direct access to the latest configuration options and examples